### PR TITLE
Update default JVM options and System props

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -125,15 +125,10 @@ The plugin defines the following extension properties in the `gatling` closure
 |List<String>
 |[source,groovy]
 ----
-['-server', '-Xmx1G',
-'-XX:+UseG1GC', '-XX:MaxGCPauseMillis=30',
-'-XX:G1HeapRegionSize=16m',
-'-XX:InitiatingHeapOccupancyPercent=75',
-'-XX:+ParallelRefProcEnabled',
-'-XX:+PerfDisableSharedMem',
-'-XX:+AggressiveOpts',
-'-XX:+OptimizeStringConcat',
-'-XX:+HeapDumpOnOutOfMemoryError']
+['-server', '-Xmx1G', '-XX:+HeapDumpOnOutOfMemoryError',
+'-XX:+UseG1GC', '-XX:+ParallelRefProcEnabled',
+'-XX:MaxInlineLevel=20', '-XX:MaxTrivialSize=12',
+'-XX:-UseBiasedLocking']
 ----
 |Additional arguments passed to JVM when executing `Gatling` simulations
 
@@ -141,8 +136,7 @@ The plugin defines the following extension properties in the `gatling` closure
 |Map<String, Object>
 |[source,groovy]
 ----
-['java.net.preferIPv4Stack': true,
-'java.net.preferIPv6Addresses': false]
+['java.net.preferIPv6Addresses': true]
 ----
 |Additional systems properties passed to JVM together with caller JVM system properties
 

--- a/src/main/groovy/io/gatling/gradle/JvmConfigurable.groovy
+++ b/src/main/groovy/io/gatling/gradle/JvmConfigurable.groovy
@@ -3,21 +3,19 @@ package io.gatling.gradle
 trait JvmConfigurable {
 
     static final List<String> DEFAULT_JVM_ARGS = [
+        '-server',
         '-Xmx1G',
         '-XX:+HeapDumpOnOutOfMemoryError',
         '-XX:+UseG1GC',
-        '-XX:MaxGCPauseMillis=30',
-        '-XX:G1HeapRegionSize=16m',
-        '-XX:InitiatingHeapOccupancyPercent=75',
         '-XX:+ParallelRefProcEnabled',
-        '-XX:+PerfDisableSharedMem',
-        '-XX:+OptimizeStringConcat'
+        '-XX:MaxInlineLevel=20',
+        '-XX:MaxTrivialSize=12',
+        '-XX:-UseBiasedLocking'
     ]
 
-    static final Map DEFAULT_SYSTEM_PROPS = ["java.net.preferIPv4Stack": true, "java.net.preferIPv6Addresses": false]
+    static final Map DEFAULT_SYSTEM_PROPS = ["java.net.preferIPv6Addresses": true]
 
     List<String> jvmArgs
 
     Map systemProperties
-
 }


### PR DESCRIPTION
Motivation:

In Gatling 3.4.0, we are fixing our set of JVM options and System props.

Modifications:

Use the same set as gatling.sh, gatling.bat, gatling-maven-plugin, gatling-sbt and FrontLine.

Result:

Better default JVM tuning for better performance