### PR TITLE
Introduce logHttp extension property to tune HTTP logging in generated logback config file, close gatling/gatling#3949

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -25,6 +25,8 @@ class GatlingPluginExtension implements JvmConfigurable {
 
     String logLevel = "WARN"
 
+    LogHttp logHttp = LogHttp.NONE
+
     GatlingPluginExtension() {
         this.jvmArgs = DEFAULT_JVM_ARGS
         this.systemProperties = DEFAULT_SYSTEM_PROPS

--- a/src/main/groovy/io/gatling/gradle/LogHttp.groovy
+++ b/src/main/groovy/io/gatling/gradle/LogHttp.groovy
@@ -1,0 +1,11 @@
+package io.gatling.gradle
+
+enum LogHttp {
+    NONE(null), ALL("TRACE"), FAILURES("DEBUG")
+
+    final String logLevel
+
+    private LogHttp(String logLevel) {
+        this.logLevel = logLevel
+    }
+}

--- a/src/main/groovy/io/gatling/gradle/LogbackConfigTaskAction.groovy
+++ b/src/main/groovy/io/gatling/gradle/LogbackConfigTaskAction.groovy
@@ -4,7 +4,7 @@ import org.gradle.api.Action
 import org.gradle.api.Task
 
 class LogbackConfigTaskAction implements Action<Task> {
-    static def template(String logLevel) {
+    static def template(String logLevel, LogHttp logHttp) {
         """<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -13,6 +13,7 @@ class LogbackConfigTaskAction implements Action<Task> {
         </encoder>
         <immediateFlush>false</immediateFlush>
     </appender>
+    <logger name="io.gatling.http.engine.response" level="${logHttp.logLevel ?: logLevel}" />
     <root level="${logLevel}">
        <appender-ref ref="CONSOLE" />
     </root>
@@ -24,7 +25,7 @@ class LogbackConfigTaskAction implements Action<Task> {
         if (!gatlingRunTask.project.file("${GatlingPluginExtension.RESOURCES_DIR}/logback.xml").exists()) {
             new File(gatlingRunTask.project.buildDir, "resources/gatling/logback.xml").with {
                 parentFile.mkdirs()
-                text = template(gatlingExt.logLevel)
+                text = template(gatlingExt.logLevel, gatlingExt.logHttp)
             }
         }
     }

--- a/src/main/groovy/io/gatling/gradle/LogbackConfigTaskAction.groovy
+++ b/src/main/groovy/io/gatling/gradle/LogbackConfigTaskAction.groovy
@@ -5,6 +5,8 @@ import org.gradle.api.Task
 
 class LogbackConfigTaskAction implements Action<Task> {
     static def template(String logLevel, LogHttp logHttp) {
+        def httpLogger = logHttp == LogHttp.NONE ? "" : """<logger name="io.gatling.http.engine.response" level="${logHttp.logLevel}" />"""
+
         """<?xml version="1.0" encoding="UTF-8"?>
 <configuration>
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -13,7 +15,7 @@ class LogbackConfigTaskAction implements Action<Task> {
         </encoder>
         <immediateFlush>false</immediateFlush>
     </appender>
-    <logger name="io.gatling.http.engine.response" level="${logHttp.logLevel ?: logLevel}" />
+    $httpLogger
     <root level="${logLevel}">
        <appender-ref ref="CONSOLE" />
     </root>

--- a/src/test/groovy/func/LogbackConfigTaskActionTest.groovy
+++ b/src/test/groovy/func/LogbackConfigTaskActionTest.groovy
@@ -37,10 +37,7 @@ class LogbackConfigTaskActionTest extends GatlingFuncSpec {
         and:
         logbackConfig.exists()
         and:
-        def gpath = xml.parse(logbackConfig)
-        rootLevel(gpath) == "WARN"
-        and:
-        httpLevel(gpath) == "WARN"
+        rootLevel(xml.parse(logbackConfig)) == "WARN"
     }
 
     def "should set root logger level via logLevel extension"() {
@@ -53,15 +50,12 @@ class LogbackConfigTaskActionTest extends GatlingFuncSpec {
         and:
         logbackConfig.exists()
         and:
-        def gpath = xml.parse(logbackConfig)
-        rootLevel(gpath) == "QQQQ"
-        and:
-        httpLevel(gpath) == "QQQQ"
+        rootLevel(xml.parse(logbackConfig)) == "QQQQ"
     }
 
-    def "should set HTTP logger level to the same as logLevel extension via logHttp extension when value is NONE"() {
+    def "should not set HTTP logger level via logHttp extension when value is NONE"() {
         given:
-        buildFile << 'gatling { logLevel = "QQQQ" \n logHttp = "NONE" }'
+        buildFile << 'gatling { logHttp = "NONE" }'
         when:
         BuildResult result = executeGradle(PROCESS_GATLING_RESOURCES_TASK_NAME)
         then:
@@ -69,10 +63,7 @@ class LogbackConfigTaskActionTest extends GatlingFuncSpec {
         and:
         logbackConfig.exists()
         and:
-        def gpath = xml.parse(logbackConfig)
-        rootLevel(gpath) == "QQQQ"
-        and:
-        httpLevel(gpath) == "QQQQ"
+        xml.parse(logbackConfig).logger.findAll().isEmpty()
     }
 
     def "should set HTTP logger level to TRACE via logHttp extension when value is ALL"() {
@@ -85,10 +76,7 @@ class LogbackConfigTaskActionTest extends GatlingFuncSpec {
         and:
         logbackConfig.exists()
         and:
-        def gpath = xml.parse(logbackConfig)
-        rootLevel(gpath) == "WARN"
-        and:
-        httpLevel(gpath) == "TRACE"
+        httpLevel(xml.parse(logbackConfig)) == "TRACE"
     }
 
     def "should set HTTP logger level to DEBUG via logHttp extension when value is FAILURES"() {
@@ -101,10 +89,7 @@ class LogbackConfigTaskActionTest extends GatlingFuncSpec {
         and:
         logbackConfig.exists()
         and:
-        def gpath = xml.parse(logbackConfig)
-        rootLevel(gpath) == "WARN"
-        and:
-        httpLevel(gpath) == "DEBUG"
+        httpLevel(xml.parse(logbackConfig)) == "DEBUG"
     }
 
     def "should not create sample logback.xml when it exists"() {

--- a/src/test/groovy/func/LogbackConfigTaskActionTest.groovy
+++ b/src/test/groovy/func/LogbackConfigTaskActionTest.groovy
@@ -1,5 +1,6 @@
 package func
 
+import groovy.util.slurpersupport.GPathResult
 import helper.GatlingFuncSpec
 import org.gradle.testkit.runner.BuildResult
 
@@ -18,7 +19,17 @@ class LogbackConfigTaskActionTest extends GatlingFuncSpec {
         logbackConfig = new File(buildDir, "resources/gatling/logback.xml".toString())
     }
 
-    def "should create sample logback using logLevel from extension"() {
+    private def rootLevel(GPathResult gpath) {
+        gpath.root.@level
+    }
+
+    private def httpLevel(GPathResult gpath) {
+        gpath.depthFirst().find { logger ->
+            logger.@name == 'io.gatling.http.engine.response'
+        }.@level
+    }
+
+    def "should create sample logback using extension logLevel"() {
         when:
         BuildResult result = executeGradle(PROCESS_GATLING_RESOURCES_TASK_NAME)
         then:
@@ -26,10 +37,13 @@ class LogbackConfigTaskActionTest extends GatlingFuncSpec {
         and:
         logbackConfig.exists()
         and:
-        xml.parse(logbackConfig).root.@level == "WARN"
+        def gpath = xml.parse(logbackConfig)
+        rootLevel(gpath) == "WARN"
+        and:
+        httpLevel(gpath) == "WARN"
     }
 
-    def "should override logLevel via extension"() {
+    def "should set root logger level via logLevel extension"() {
         given:
         buildFile << 'gatling { logLevel = "QQQQ" }'
         when:
@@ -39,7 +53,58 @@ class LogbackConfigTaskActionTest extends GatlingFuncSpec {
         and:
         logbackConfig.exists()
         and:
-        xml.parse(logbackConfig).root.@level == "QQQQ"
+        def gpath = xml.parse(logbackConfig)
+        rootLevel(gpath) == "QQQQ"
+        and:
+        httpLevel(gpath) == "QQQQ"
+    }
+
+    def "should set HTTP logger level to the same as logLevel extension via logHttp extension when value is NONE"() {
+        given:
+        buildFile << 'gatling { logLevel = "QQQQ" \n logHttp = "NONE" }'
+        when:
+        BuildResult result = executeGradle(PROCESS_GATLING_RESOURCES_TASK_NAME)
+        then:
+        result.task(":$PROCESS_GATLING_RESOURCES_TASK_NAME").outcome == SUCCESS
+        and:
+        logbackConfig.exists()
+        and:
+        def gpath = xml.parse(logbackConfig)
+        rootLevel(gpath) == "QQQQ"
+        and:
+        httpLevel(gpath) == "QQQQ"
+    }
+
+    def "should set HTTP logger level to TRACE via logHttp extension when value is ALL"() {
+        given:
+        buildFile << 'gatling { logHttp = "ALL" }'
+        when:
+        BuildResult result = executeGradle(PROCESS_GATLING_RESOURCES_TASK_NAME)
+        then:
+        result.task(":$PROCESS_GATLING_RESOURCES_TASK_NAME").outcome == SUCCESS
+        and:
+        logbackConfig.exists()
+        and:
+        def gpath = xml.parse(logbackConfig)
+        rootLevel(gpath) == "WARN"
+        and:
+        httpLevel(gpath) == "TRACE"
+    }
+
+    def "should set HTTP logger level to DEBUG via logHttp extension when value is FAILURES"() {
+        given:
+        buildFile << 'gatling { logHttp = "FAILURES" }'
+        when:
+        BuildResult result = executeGradle(PROCESS_GATLING_RESOURCES_TASK_NAME)
+        then:
+        result.task(":$PROCESS_GATLING_RESOURCES_TASK_NAME").outcome == SUCCESS
+        and:
+        logbackConfig.exists()
+        and:
+        def gpath = xml.parse(logbackConfig)
+        rootLevel(gpath) == "WARN"
+        and:
+        httpLevel(gpath) == "DEBUG"
     }
 
     def "should not create sample logback.xml when it exists"() {


### PR DESCRIPTION
Motivation:

In all other launchers, we document a special slf4j logger to enable logging on either all or failed HTTP traffic.
The standard approach with gatling-gradle-plugin is to have it generate the logback config file, hence users are not aware of this logging option.

Modifications:

Introduce a new extension property named `logHttp` that can take the values `NONE`, `ALL` and `FAILURES` that would set the HTTP logger level respectively to the same as root, TRACE and DEBUG.

Result:

gatling-gradle-plugin users now have a convenient option for tuning HTTP logging level.