### PR TITLE
Chore: Upgrade gradle to 6.6.1

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/test/groovy/func/GradleCompatibilitySpec.groovy
+++ b/src/test/groovy/func/GradleCompatibilitySpec.groovy
@@ -33,7 +33,7 @@ class GradleCompatibilitySpec extends GatlingFuncSpec {
         then:
         result.task(":tasks").outcome == SUCCESS
         where:
-        gradleVersion << ["4.0.1", "4.10.2", "5.0", "5.6.4", "6.0", "6.3", "6.4.1", "6.6.1"]
+        gradleVersion << ["4.0.1", "4.10.2", "5.0", "5.6.4", "6.0", "6.3", "6.4.1"]
     }
 
     @Unroll

--- a/src/test/groovy/func/GradleCompatibilitySpec.groovy
+++ b/src/test/groovy/func/GradleCompatibilitySpec.groovy
@@ -33,7 +33,7 @@ class GradleCompatibilitySpec extends GatlingFuncSpec {
         then:
         result.task(":tasks").outcome == SUCCESS
         where:
-        gradleVersion << ["4.0.1", "4.10.2", "5.0", "5.6.4", "6.0", "6.3"]
+        gradleVersion << ["4.0.1", "4.10.2", "5.0", "5.6.4", "6.0", "6.3", "6.4.1", "6.6.1"]
     }
 
     @Unroll

--- a/src/test/groovy/unit/GatlingPluginTest.groovy
+++ b/src/test/groovy/unit/GatlingPluginTest.groovy
@@ -4,6 +4,7 @@ import io.gatling.gradle.GatlingPluginExtension
 import io.gatling.gradle.GatlingRunTask
 import io.gatling.gradle.LogbackConfigTaskAction
 import helper.GatlingUnitSpec
+import org.gradle.api.Task
 import org.gradle.language.jvm.tasks.ProcessResources
 
 class GatlingPluginTest extends GatlingUnitSpec {
@@ -78,15 +79,9 @@ class GatlingPluginTest extends GatlingUnitSpec {
 
     def "should create processGatlingResources task"() {
         expect:
-        with(project.tasks.getByName("processGatlingResources")) {
-            it instanceof ProcessResources
-            it.actions.find { action ->
-                try {
-                    action.action instanceof LogbackConfigTaskAction
-                } catch (MissingPropertyException e) {
-                    false
-                }
-            } != null
+        with(project.tasks.getByName("processGatlingResources")) { Task task ->
+            task instanceof ProcessResources
+            task.actions.any { it.hasProperty("action") && it.action instanceof LogbackConfigTaskAction }
         }
     }
 }

--- a/src/test/groovy/unit/GatlingPluginTest.groovy
+++ b/src/test/groovy/unit/GatlingPluginTest.groovy
@@ -79,17 +79,9 @@ class GatlingPluginTest extends GatlingUnitSpec {
 
     def "should create processGatlingResources task"() {
         expect:
-<<<<<<< HEAD
         with(project.tasks.getByName("processGatlingResources")) { Task task ->
             task instanceof ProcessResources
             task.actions.any { it.hasProperty("action") && it.action instanceof LogbackConfigTaskAction }
-=======
-        with(project.tasks.getByName("processGatlingResources")) {
-            it instanceof ProcessResources
-            it.actions.find { action ->
-                action.action ? action.action instanceof LogbackConfigTaskAction : false
-            } != null
->>>>>>> 4f998f7... tentative to fix test
         }
     }
 }

--- a/src/test/groovy/unit/GatlingPluginTest.groovy
+++ b/src/test/groovy/unit/GatlingPluginTest.groovy
@@ -79,9 +79,17 @@ class GatlingPluginTest extends GatlingUnitSpec {
 
     def "should create processGatlingResources task"() {
         expect:
+<<<<<<< HEAD
         with(project.tasks.getByName("processGatlingResources")) { Task task ->
             task instanceof ProcessResources
             task.actions.any { it.hasProperty("action") && it.action instanceof LogbackConfigTaskAction }
+=======
+        with(project.tasks.getByName("processGatlingResources")) {
+            it instanceof ProcessResources
+            it.actions.find { action ->
+                action.action ? action.action instanceof LogbackConfigTaskAction : false
+            } != null
+>>>>>>> 4f998f7... tentative to fix test
         }
     }
 }

--- a/src/test/groovy/unit/GatlingPluginTest.groovy
+++ b/src/test/groovy/unit/GatlingPluginTest.groovy
@@ -80,8 +80,13 @@ class GatlingPluginTest extends GatlingUnitSpec {
         expect:
         with(project.tasks.getByName("processGatlingResources")) {
             it instanceof ProcessResources
-            it != null
-            it.actions.find { it.action instanceof LogbackConfigTaskAction } != null
+            it.actions.find { action ->
+                try {
+                    action.action instanceof LogbackConfigTaskAction
+                } catch (MissingPropertyException e) {
+                    false
+                }
+            } != null
         }
     }
 }


### PR DESCRIPTION
Motivation:

We want to make sure we support the latest stable release, which is 6.6.1 as of now.

We also want to be notified of deprecations so we can anticipate on the required changes in order to support the next major release (gradle 7).

Modifications:

* build the plugin with latest 6.6.1 as of now
* add 6.6.1 to the versions tested in GradleCompatibilitySpec

Result:

Plugin is now built and tested against the latest stable release.