### PR TITLE
We should stick to preferIPv6Addresses's default (false)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -163,7 +163,7 @@ The plugin defines the following extension properties in the `gatling` closure:
 |
 [source, groovy]
 ----
-['java.net.preferIPv6Addresses': true]
+['java.net.preferIPv6Addresses': false]
 ----
 | Additional systems properties passed to JVM together with caller JVM system
 properties

--- a/src/main/groovy/io/gatling/gradle/JvmConfigurable.groovy
+++ b/src/main/groovy/io/gatling/gradle/JvmConfigurable.groovy
@@ -13,7 +13,7 @@ trait JvmConfigurable {
         '-XX:-UseBiasedLocking'
     ]
 
-    static final Map DEFAULT_SYSTEM_PROPS = ["java.net.preferIPv6Addresses": true]
+    static final Map DEFAULT_SYSTEM_PROPS = [:]
 
     List<String> jvmArgs
 


### PR DESCRIPTION
Motivation:

It's probably not safe to enforce IPv6 over IPv4 and there's no clear benefits.

Modification:

Revert java.net.preferIPv6Addresses change introduced in 456e22b.

Result:

Use JVM's default wrt net behavior