### PR TITLE
Prepare release 3.4.0

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = Gatling Plugin for Gradle
-:gatlingToolVersion: 3.3.1
-:scalaVersion: 2.12.8
+:gatlingToolVersion: 3.4.0
+:scalaVersion: 2.12.12
 :toc: macro
 :icons: font
 

--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -8,9 +8,9 @@ class GatlingPluginExtension implements JvmConfigurable {
 
     static final String RESOURCES_DIR = "src/gatling/resources"
 
-    static final String GATLING_TOOL_VERSION = '3.3.1'
+    static final String GATLING_TOOL_VERSION = '3.4.0'
 
-    static final String SCALA_VERSION = '2.12.8'
+    static final String SCALA_VERSION = '2.12.12'
 
     static final Closure DEFAULT_SIMULATIONS = { include("**/*Simulation*.scala") }
 

--- a/src/test/groovy/helper/GatlingSpec.groovy
+++ b/src/test/groovy/helper/GatlingSpec.groovy
@@ -28,7 +28,10 @@ abstract class GatlingSpec extends Specification {
         buildFile = projectDir.newFile("build.gradle")
         buildFile.text = """
 plugins { id 'io.gatling.gradle' }
-dependencies { gatling group: 'commons-lang', name: 'commons-lang', version: '2.6' }
+dependencies {
+  gatling group: 'commons-lang', name: 'commons-lang', version: '2.6'
+  gatling group: 'org.json4s', name: 'json4s-jackson_2.12', version: '3.6.9'
+}
 """
     }
 }

--- a/src/test/resources/gatling-debug/src/gatling/scala/GatlingDebugSimulation.scala
+++ b/src/test/resources/gatling-debug/src/gatling/scala/GatlingDebugSimulation.scala
@@ -42,5 +42,5 @@ class GatlingDebugSimulation extends Simulation {
 
   println(s"@@@@.sys ${write(System.getProperties.asScala)}}")
 
-  setUp(scenario("Scenario Name").pause(1).inject(atOnceUsers(0)))
+  setUp(scenario("Scenario Name").pause(1).inject(atOnceUsers(1)))
 }


### PR DESCRIPTION
Motivation:

Edit @slandelle: Gatling 3.4.0 is about to be released (binaries are available on maven central but official announcement will only happen tomorrow once everything is online, FrontLine included)

Modifications:
 * 3.4.0 in documentation
 * 3.4.0 in gatling dependencies

Result:
Ready for the release