### PR TITLE
Permit the setting of environment variables

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -33,5 +33,6 @@ class GatlingPluginExtension implements JvmConfigurable {
     GatlingPluginExtension() {
         this.jvmArgs = DEFAULT_JVM_ARGS
         this.systemProperties = DEFAULT_SYSTEM_PROPS
+        this.environment = DEFAULT_ENVIRONMENT
     }
 }

--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -33,6 +33,5 @@ class GatlingPluginExtension implements JvmConfigurable {
     GatlingPluginExtension() {
         this.jvmArgs = DEFAULT_JVM_ARGS
         this.systemProperties = DEFAULT_SYSTEM_PROPS
-        this.environment = DEFAULT_ENVIRONMENT
     }
 }

--- a/src/main/groovy/io/gatling/gradle/GatlingRunTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingRunTask.groovy
@@ -59,6 +59,8 @@ class GatlingRunTask extends DefaultTask implements JvmConfigurable {
                 exec.jvmArgs this.jvmArgs ?: gatlingExt.jvmArgs
                 exec.systemProperties System.properties
                 exec.systemProperties this.systemProperties ?: gatlingExt.systemProperties
+                exec.environment += gatlingExt.environment
+                exec.environment += this.environment
 
                 def logbackFile = LogbackConfigTask.logbackFile(project.buildDir)
                 if (logbackFile.exists()) {

--- a/src/main/groovy/io/gatling/gradle/JvmConfigurable.groovy
+++ b/src/main/groovy/io/gatling/gradle/JvmConfigurable.groovy
@@ -15,11 +15,9 @@ trait JvmConfigurable {
 
     static final Map DEFAULT_SYSTEM_PROPS = [:]
 
-    static final Map DEFAULT_ENVIRONMENT = [:]
-
     List<String> jvmArgs
 
     Map systemProperties
 
-    Map environment
+    Map environment = [:]
 }

--- a/src/main/groovy/io/gatling/gradle/JvmConfigurable.groovy
+++ b/src/main/groovy/io/gatling/gradle/JvmConfigurable.groovy
@@ -15,7 +15,11 @@ trait JvmConfigurable {
 
     static final Map DEFAULT_SYSTEM_PROPS = [:]
 
+    static final Map DEFAULT_ENVIRONMENT = [:]
+
     List<String> jvmArgs
 
     Map systemProperties
+
+    Map environment
 }

--- a/src/test/groovy/func/WhenRunSimulationSysPropsJvmArgsSpec.groovy
+++ b/src/test/groovy/func/WhenRunSimulationSysPropsJvmArgsSpec.groovy
@@ -133,6 +133,41 @@ gatlingRun {
         }
     }
 
+    def "should set additional env vars from extension"() {
+        given: "set via extension"
+        buildFile << """
+gatling {
+    environment['env1'] = 'env1_value'
+}
+"""
+        when:
+        def result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            env["env1"] == "env1_value"
+        }
+    }
+
+    def "should override gatling env vars with gatlingRun"() {
+        given: "override via gatlingRun"
+        buildFile << """
+gatling {
+    environment = ['env1': 'aaa', 'env2': 'bbb']
+}
+gatlingRun {
+    environment = ['env2': 'ddd', 'env3': 'ccc']
+}
+"""
+        when:
+        def result = executeGradle(GATLING_RUN_TASK_NAME)
+        then:
+        with(new GatlingDebug(result)) {
+            env["env1"] == "aaa"
+            env["env2"] == "ddd"
+            env["env3"] == "ccc"
+        }
+    }
+
     def "should pass env vars upstream"() {
         given:
         environmentVariables.set("GRADLE_GATLING_ENV_UPSTREAM", "env_upstream_value")


### PR DESCRIPTION
This was modeled on the way [environment variables work with the JavaExec task](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:environment).  (The property is called "environment" and assigning a map doesn't clobber existing variables but only sets additional variables.)  It was also modeled on the way the plugin handles system properties: environment variables set using the gatling extension are overridden by variables set in gatlingRun tasks.