### PR TITLE
Add scala compiler options, closes gatling/gatling#4040

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -74,6 +74,19 @@ class GatlingPlugin implements Plugin<Project> {
             gatlingRuntimeOnly project.sourceSets.gatling.output
         }
 
+        project.tasks.getByName("compileGatlingScala").configure {
+            scalaCompileOptions.with {
+                additionalParameters = [
+                    "-target:jvm-1.8",
+                    "-deprecation",
+                    "-feature",
+                    "-unchecked",
+                    "-language:implicitConversions",
+                    "-language:postfixOps"
+                ]
+            }
+        }
+
         project.afterEvaluate { Project evaluatedProject ->
             evaluatedProject.dependencies {
                 def evaluatedExt = evaluatedProject.extensions.getByType(GatlingPluginExtension)

--- a/src/test/resources/gradle-layout/src/gatling/scala/computerdatabase/BasicSimulation.scala
+++ b/src/test/resources/gradle-layout/src/gatling/scala/computerdatabase/BasicSimulation.scala
@@ -32,9 +32,9 @@ class BasicSimulation extends Simulation {
 
   val scn = scenario("Scenario Name") // A scenario is a chain of requests and pauses
     .exec(http("request_1").get("/"))
-    .pause(1) // Note that Gatling has recorded real time pauses
+    .pause(1 second) // Note that Gatling has recorded real time pauses
     .exec(http("request_2").get("/computers?f=macbook"))
-    .pause(1)
+    .pause(1 second)
     .exec(http("request_3").get("/computers/6"))
 
   setUp(scn.inject(atOnceUsers(1)).protocols(httpConf)).assertions(


### PR DESCRIPTION
gatling/gatling#4040
Motivation:
By default, this plugin should be compatible with the tutorial examples.

Modifications:
Add default scala compiler options.

Result:
 * By default, user are now able to:
    - use postfix notation `-language:postfixOps`
    - use implicit conversions `-language:implicitConversions`
    - see warning when using deprecated feature `-deprecation`
    - see help and location when using a feature that requires explicit import `-feature`
 * The user may override that configuration. Sample:
    ```groovy
    tasks.getByName("compileGatlingScala") {
      scalaCompileOptions.with {
        additionalParameters = ["-target:jvm-1.8"]
      }
    }
    ```