### PR TITLE
Gatling Enterprise upload package, closes MISC-231

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ repositories {
 }
 
 dependencies {
+  implementation "io.gatling:gatling-enterprise-plugin-commons:0.0.3"
   implementation "com.github.jengelman.gradle.plugins:shadow:5.2.0"
   testImplementation('org.spockframework:spock-core:1.3-groovy-2.4') {
     exclude module: 'groovy-all'

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterprisePublishTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterprisePublishTask.groovy
@@ -1,0 +1,18 @@
+package io.gatling.gradle
+
+import io.gatling.plugin.util.EnterpriseClient
+import io.gatling.plugin.util.OkHttpEnterpriseClient
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.TaskAction
+
+@CacheableTask
+class GatlingEnterprisePublishTask extends DefaultTask {
+
+    @TaskAction
+    void publish() {
+        def gatling = project.extensions.getByType(GatlingPluginExtension)
+        EnterpriseClient enterpriseClient = new OkHttpEnterpriseClient(gatling.enterprise.url, gatling.enterprise.apiToken)
+        enterpriseClient.uploadPackage(gatling.enterprise.packageId, inputs.files.singleFile)
+    }
+}

--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -21,6 +21,8 @@ class GatlingPlugin implements Plugin<Project> {
 
     public static def ENTERPRISE_PACKAGE_TASK_NAME = "gatlingEnterprisePackage"
 
+    public static def ENTERPRISE_PUBLISH_TASK_NAME = "gatlingEnterprisePublish"
+
     /**
      * @deprecated Please use {@link io.gatling.gradle.GatlingPlugin#ENTERPRISE_PACKAGE_TASK_NAME} instead
      */
@@ -51,6 +53,7 @@ class GatlingPlugin implements Plugin<Project> {
         }
 
         def gatlingEnterprisePackage = createEnterprisePackageTask(project)
+        createEnterprisePublishTask(project, gatlingEnterprisePackage)
 
         project.afterEvaluate {
             if (project.plugins.findPlugin('io.gatling.frontline.gradle')) {
@@ -84,6 +87,16 @@ class GatlingPlugin implements Plugin<Project> {
                     include "${simulationFQN.replace('.', '/')}.scala"
                 }
             }
+        }
+    }
+
+    void createEnterprisePublishTask(Project project, GatlingEnterprisePackageTask gatlingEnterprisePackageTask) {
+        project.tasks.create(
+            name: ENTERPRISE_PUBLISH_TASK_NAME,
+            type: GatlingEnterprisePublishTask
+        ) {
+            inputs.files gatlingEnterprisePackageTask
+            dependsOn(gatlingEnterprisePackageTask)
         }
     }
 

--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -2,6 +2,51 @@ package io.gatling.gradle
 
 class GatlingPluginExtension implements JvmConfigurable {
 
+    private static final String API_TOKEN_PROPERTY = "gatling.enterprise.apiToken"
+    private static final String API_TOKEN_ENV = "GATLING_ENTERPRISE_API_TOKEN"
+
+    final static class Enterprise {
+        private String apiToken
+        private UUID packageId
+        private URL url = new URL("https://cloud.gatling.io/api/public")
+
+        def url(String url) {
+            this.url = new URL(url)
+        }
+
+        def packageId(String packageId) {
+            this.packageId = UUID.fromString(packageId)
+        }
+
+        def apiToken(String apiToken) {
+            this.apiToken = apiToken
+        }
+
+        String getApiToken() {
+            if (apiToken == null) {
+                return System.getProperty(API_TOKEN_PROPERTY, System.getenv(API_TOKEN_ENV))
+            } else {
+                return apiToken
+            }
+        }
+
+        UUID getPackageId() {
+            return packageId
+        }
+
+        URL getUrl() {
+            return url
+        }
+    }
+
+    Enterprise enterprise = new Enterprise()
+
+    def enterprise(Closure c) {
+        c.resolveStrategy = Closure.DELEGATE_FIRST
+        c.delegate = enterprise
+        c()
+    }
+
     static final String GATLING_MAIN_CLASS = 'io.gatling.app.Gatling'
 
     static final String SIMULATIONS_DIR = "src/gatling/scala"


### PR DESCRIPTION
**Motivation:**
Upload artifact from gradle plugin on Gatling Enterprise

**Modification:**
* Use `gatling-enterprise-plugin-commons` enterprise client to upload
* Add `gatlingEnterprisePublish` goal to upload package

**Result:**
Upload using `gatlingEnterprisePublish`.
Need configuration of `packageId` or `apiToken`.