### PR TITLE
Properly set the 'tests' classifier for gatlingEnterprisePackage task

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -107,11 +107,7 @@ class GatlingPlugin implements Plugin<Project> {
     GatlingEnterprisePackageTask createEnterprisePackageTask(Project project) {
         GatlingEnterprisePackageTask gatlingEnterprisePackage = project.tasks.create(name: ENTERPRISE_PACKAGE_TASK_NAME, type: GatlingEnterprisePackageTask)
 
-        gatlingEnterprisePackage.conventionMapping.with {
-            map("classifier") {
-                "tests"
-            }
-        }
+        gatlingEnterprisePackage.classifier = "tests"
 
         gatlingEnterprisePackage.exclude(
             "META-INF/LICENSE",

--- a/src/test/groovy/func/GradleCompatibilitySpec.groovy
+++ b/src/test/groovy/func/GradleCompatibilitySpec.groovy
@@ -33,7 +33,7 @@ class GradleCompatibilitySpec extends GatlingFuncSpec {
         then:
         result.task(":tasks").outcome == SUCCESS
         where:
-        gradleVersion << ["5.0", "5.6.4", "6.0", "6.3", "6.4.1", "6.9.1", "7.0", "7.1.1"]
+        gradleVersion << ["5.0", "5.6.4", "6.0", "6.3", "6.4.1", "6.9.1", "7.0", "7.3"]
     }
 
     @Unroll

--- a/src/test/groovy/func/WhenPackageSpec.groovy
+++ b/src/test/groovy/func/WhenPackageSpec.groovy
@@ -18,7 +18,7 @@ class WhenPackageSpec extends GatlingFuncSpec {
         result.task(":$ENTERPRISE_PACKAGE_TASK_NAME").outcome == SUCCESS
         result.task(":gatlingClasses").outcome == SUCCESS
         def artifactId = projectDir.root.getName()
-        def artifact = new File(buildDir, "libs/${artifactId}.jar")
+        def artifact = new File(buildDir, "libs/${artifactId}-tests.jar")
         and: "artifact was created"
         artifact.isFile()
     }
@@ -33,7 +33,7 @@ class WhenPackageSpec extends GatlingFuncSpec {
         result.task(":$ENTERPRISE_PACKAGE_TASK_NAME").outcome == SUCCESS
         result.task(":gatlingClasses").outcome == SUCCESS
         def artifactId = projectDir.root.getName()
-        def artifact = new File(buildDir, "libs/${artifactId}.jar")
+        def artifact = new File(buildDir, "libs/${artifactId}-tests.jar")
         and: "artifact was created"
         artifact.isFile()
     }


### PR DESCRIPTION
I think the code with `conventionMapping` is outdated? It certainly doesn't work in my tests using Gradle 7. But anyway, we can directly configure the classifier on the `ShadowJar` task which we extend.