### PR TITLE
feat: Start Gatling Enterprise Simulation 

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -51,3 +51,5 @@ Steps to be able to dev test this plugin:
       sourceCompatibility = 1.8
       targetCompatibility = 1.8
       ```
+
+You could also add the `maven-publish` plugin and do a `gradle publishToMavenLocal`.

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-  implementation "io.gatling:gatling-enterprise-plugin-commons:0.0.3-M20211217085936"
+  implementation "io.gatling:gatling-enterprise-plugin-commons:0.0.3-M20211221165132"
   implementation "com.github.jengelman.gradle.plugins:shadow:5.2.0"
   testImplementation('org.spockframework:spock-core:1.3-groovy-2.4') {
     exclude module: 'groovy-all'

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-  implementation "io.gatling:gatling-enterprise-plugin-commons:0.0.3"
+  implementation "io.gatling:gatling-enterprise-plugin-commons:0.0.3-M20211217085936"
   implementation "com.github.jengelman.gradle.plugins:shadow:5.2.0"
   testImplementation('org.spockframework:spock-core:1.3-groovy-2.4') {
     exclude module: 'groovy-all'

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseStartTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseStartTask.groovy
@@ -1,0 +1,50 @@
+package io.gatling.gradle
+
+import io.gatling.plugin.util.EnterpriseClient
+import io.gatling.plugin.util.OkHttpEnterpriseClient
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskExecutionException
+
+@CacheableTask
+class GatlingEnterpriseStartTask extends DefaultTask {
+
+    @Internal
+    Closure simulations
+
+    @TaskAction
+    void publish() {
+        def gatling = project.extensions.getByType(GatlingPluginExtension)
+        EnterpriseClient enterpriseClient = new OkHttpEnterpriseClient(gatling.enterprise.url, gatling.enterprise.apiToken)
+
+        def systemProps = gatling.enterprise.systemProps ?: [:]
+
+        if (!gatling.enterprise.simulationId && !gatling.enterprise.simulationClass) {
+            throw new TaskExecutionException(this,
+                new IllegalArgumentException("You need to either configure gatling.enterprise.simulationId if you want to start an existing simulation," +
+                "or gatling.enterprise.simulationClass if you want to create a new simulation")
+            )
+        }
+
+        def simulationAndRunSummary
+        if (gatling.enterprise.simulationId) {
+            simulationAndRunSummary = enterpriseClient.startSimulation(gatling.enterprise.simulationId, systemProps, inputs.files.singleFile)
+        } else {
+            simulationAndRunSummary = enterpriseClient.createAndStartSimulation(project.group.toString(), project.name, gatling.enterprise.simulationClass, systemProps, inputs.files.singleFile)
+            def simulation = simulationAndRunSummary.simulation
+            getLogger().info("""
+                         |Created simulation ${simulation.name} with ID ${simulation.id}
+                         |
+                         |To start again the same simulation, add the following Gradle configuration:
+                         |gatling.enterprise.simulationId "${simulation.id}"
+                         |gatling.enterprise.packageId "${simulation.pkgId}"
+                         |""".stripMargin())
+        }
+        getLogger().info("""
+                         |Simulation ${simulationAndRunSummary.simulation.name} successfully started
+                         |Once running, reports will be available at: ${gatling.enterprise.url.toExternalForm() + simulationAndRunSummary.runSummary.reportsPath}
+                         |""".stripMargin())
+    }
+}

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseStartTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseStartTask.groovy
@@ -1,7 +1,6 @@
 package io.gatling.gradle
 
 import io.gatling.plugin.util.EnterpriseClient
-import io.gatling.plugin.util.OkHttpEnterpriseClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Internal
@@ -17,7 +16,7 @@ class GatlingEnterpriseStartTask extends DefaultTask {
     @TaskAction
     void publish() {
         def gatling = project.extensions.getByType(GatlingPluginExtension)
-        EnterpriseClient enterpriseClient = new OkHttpEnterpriseClient(gatling.enterprise.url, gatling.enterprise.apiToken)
+        EnterpriseClient enterpriseClient = gatling.enterprise.getEnterpriseClient(project.version.toString())
 
         def systemProps = gatling.enterprise.systemProps ?: [:]
 

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseStartTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseStartTask.groovy
@@ -31,7 +31,12 @@ class GatlingEnterpriseStartTask extends DefaultTask {
         if (gatling.enterprise.simulationId) {
             simulationAndRunSummary = enterpriseClient.startSimulation(gatling.enterprise.simulationId, systemProps, inputs.files.singleFile)
         } else {
-            simulationAndRunSummary = enterpriseClient.createAndStartSimulation(project.group.toString(), project.name, gatling.enterprise.simulationClass, systemProps, inputs.files.singleFile)
+            simulationAndRunSummary = enterpriseClient.createAndStartSimulation(
+                gatling.enterprise.teamId,
+                project.group.toString(),
+                project.name,
+                gatling.enterprise.simulationClass,
+                systemProps, inputs.files.singleFile)
             def simulation = simulationAndRunSummary.simulation
             getLogger().info("""
                          |Created simulation ${simulation.name} with ID ${simulation.id}

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
@@ -1,7 +1,6 @@
 package io.gatling.gradle
 
 import io.gatling.plugin.util.EnterpriseClient
-import io.gatling.plugin.util.OkHttpEnterpriseClient
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.TaskAction
@@ -12,7 +11,7 @@ class GatlingEnterpriseUploadTask extends DefaultTask {
     @TaskAction
     void publish() {
         def gatling = project.extensions.getByType(GatlingPluginExtension)
-        EnterpriseClient enterpriseClient = new OkHttpEnterpriseClient(gatling.enterprise.url, gatling.enterprise.apiToken)
+        EnterpriseClient enterpriseClient = gatling.enterprise.getEnterpriseClient(project.version.toString())
         enterpriseClient.uploadPackage(gatling.enterprise.packageId, inputs.files.singleFile)
     }
 }

--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -23,6 +23,8 @@ class GatlingPlugin implements Plugin<Project> {
 
     public static def ENTERPRISE_UPLOAD_TASK_NAME = "gatlingEnterpriseUpload"
 
+    public static def ENTERPRISE_START_TASK_NAME = "gatlingEnterpriseStart"
+
     /**
      * @deprecated Please use {@link io.gatling.gradle.GatlingPlugin#ENTERPRISE_PACKAGE_TASK_NAME} instead
      */
@@ -54,6 +56,7 @@ class GatlingPlugin implements Plugin<Project> {
 
         def gatlingEnterprisePackage = createEnterprisePackageTask(project)
         createEnterpriseUploadTask(project, gatlingEnterprisePackage)
+        createEnterpriseStartTask(project, gatlingEnterprisePackage)
 
         project.afterEvaluate {
             if (project.plugins.findPlugin('io.gatling.frontline.gradle')) {
@@ -98,6 +101,16 @@ class GatlingPlugin implements Plugin<Project> {
         project.tasks.create(
             name: ENTERPRISE_UPLOAD_TASK_NAME,
             type: GatlingEnterpriseUploadTask
+        ) {
+            inputs.files gatlingEnterprisePackageTask
+            dependsOn(gatlingEnterprisePackageTask)
+        }
+    }
+
+    void createEnterpriseStartTask(Project project, GatlingEnterprisePackageTask gatlingEnterprisePackageTask) {
+        project.tasks.create(
+            name: ENTERPRISE_START_TASK_NAME,
+            type: GatlingEnterpriseStartTask
         ) {
             inputs.files gatlingEnterprisePackageTask
             dependsOn(gatlingEnterprisePackageTask)

--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -1,27 +1,92 @@
 package io.gatling.gradle
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
 class GatlingPluginExtension implements JvmConfigurable {
 
     private static final String API_TOKEN_PROPERTY = "gatling.enterprise.apiToken"
     private static final String API_TOKEN_ENV = "GATLING_ENTERPRISE_API_TOKEN"
+    private static final String SIMULATION_ID_PROPERTY = "gatling.enterprise.simulationId"
+    private static final String SIMULATION_ID_ENV = "GATLING_ENTERPRISE_SIMULATION_ID"
+    private static final String PUBLIC_API_PATH = "/api/public"
+
 
     final static class Enterprise {
         private String apiToken
+        private UUID simulationId
         private UUID packageId
+        private Map<String, String> systemProps
         private URL url = new URL("https://cloud.gatling.io/api/public")
+        private String simulationClass
 
-        def url(String url) {
-            this.url = new URL(url)
+        def setUrl(String url) {
+            this.url = new URL(url + PUBLIC_API_PATH)
         }
 
-        def packageId(String packageId) {
+        def url(String url) {
+            setUrl(url)
+        }
+
+        def setSimulationId(String simulationId) {
+            this.simulationId = UUID.fromString(simulationId)
+        }
+
+        def simulationId(String simulationId) {
+            setSimulationId(simulationId)
+        }
+
+        def setSystemProps(Map<String, String> systemProps) {
+            this.systemProps = systemProps
+        }
+
+        def systemProps(Map<String, String> systemProps) {
+            setSystemProps(systemProps)
+        }
+
+        def setPackageId(String packageId) {
             this.packageId = UUID.fromString(packageId)
         }
 
-        def apiToken(String apiToken) {
+        def packageId(String packageId) {
+            setPackageId(packageId)
+        }
+
+        def setApiToken(String apiToken) {
             this.apiToken = apiToken
         }
 
+        def apiToken(String apiToken) {
+            setApiToken(apiToken)
+        }
+
+        def setSimulationClass(String simulationClass) {
+            this.simulationClass = simulationClass
+        }
+
+        def simulationClass(String simulationClass) {
+            setSimulationClass(simulationClass)
+        }
+
+        @Input
+        @Optional
+        UUID getSimulationId() {
+            if (simulationId == null) {
+                def systemSimulationId = System.getProperty(SIMULATION_ID_PROPERTY, System.getenv(SIMULATION_ID_ENV))
+                return systemSimulationId ? UUID.fromString(systemSimulationId) : null
+            } else {
+                return simulationId
+            }
+        }
+
+        @Input
+        @Optional
+        Map<String, String> getSystemProps() {
+            return systemProps
+        }
+
+        @Input
+        @Optional
         String getApiToken() {
             if (apiToken == null) {
                 return System.getProperty(API_TOKEN_PROPERTY, System.getenv(API_TOKEN_ENV))
@@ -30,12 +95,22 @@ class GatlingPluginExtension implements JvmConfigurable {
             }
         }
 
+        @Input
+        @Optional
         UUID getPackageId() {
             return packageId
         }
 
+        @Input
+        @Optional
         URL getUrl() {
             return url
+        }
+
+        @Input
+        @Optional
+        String getSimulationClass() {
+            return simulationClass
         }
     }
 

--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -18,6 +18,7 @@ class GatlingPluginExtension implements JvmConfigurable {
     final static class Enterprise {
         private String apiToken
         private UUID simulationId
+        private UUID teamId
         private UUID packageId
         private Map<String, String> systemProps
         private URL url = new URL("https://cloud.gatling.io/api/public")
@@ -37,6 +38,14 @@ class GatlingPluginExtension implements JvmConfigurable {
 
         def simulationId(String simulationId) {
             setSimulationId(simulationId)
+        }
+
+        def setTeamId(String teamId) {
+            this.teamId = UUID.fromString(teamId)
+        }
+
+        def teamId(String teamId) {
+            setTeamId(teamId)
         }
 
         def setSystemProps(Map<String, String> systemProps) {

--- a/src/main/groovy/io/gatling/gradle/JvmConfigurable.groovy
+++ b/src/main/groovy/io/gatling/gradle/JvmConfigurable.groovy
@@ -35,6 +35,10 @@ trait JvmConfigurable {
         this.jvmArgs = jvmArgs
     }
 
+    void jvmArgs(List<String> jvmArgs) {
+        setJvmArgs(jvmArgs)
+    }
+
     private Map systemProperties
 
     @Input
@@ -47,6 +51,10 @@ trait JvmConfigurable {
         this.systemProperties = systemProperties
     }
 
+    void systemProperties(Map systemProperties) {
+        setSystemProperties(systemProperties)
+    }
+
     private Map environment = [:]
 
     @Input
@@ -56,5 +64,9 @@ trait JvmConfigurable {
 
     void setEnvironment(Map environment) {
         this.environment = environment
+    }
+
+    void environment(Map environment) {
+        setEnvironment(environment)
     }
 }


### PR DESCRIPTION
Motivation:
- We should be able to start a GE simulation / create a basic one

Modification:
- Gradle configuration now allows = and nothing
- added gatlingEnterpriseStart task
- task starts a simulation if gatling.enterprise.simulationId is present
- task creates a simulation if there is no simulationId and gatling.enterprise.className is present
- check version support

ref: MISC-303