### PR TITLE
feat: avoid caching simulations result

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingRunTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingRunTask.groovy
@@ -16,12 +16,15 @@ import java.nio.file.Path
 import java.nio.file.Paths
 
 class GatlingRunTask extends DefaultTask implements JvmConfigurable {
-
     @Internal
     Closure simulations
 
     @OutputDirectory
     File gatlingReportDir = project.file("${project.reportsDir}/gatling")
+
+    GatlingRunTask() {
+        outputs.upToDateWhen { false }
+    }
 
     @InputFiles
     FileTree getJavaSimulationSources() {

--- a/src/test/groovy/func/WhenRunSimulationSpec.groovy
+++ b/src/test/groovy/func/WhenRunSimulationSpec.groovy
@@ -79,7 +79,7 @@ gatling.charting.noReports = true
         }
     }
 
-    def "should not run gatling if no changes to source code"() {
+    def "should run gatling twice even if no changes to source code"() {
         given:
         prepareTest()
         buildFile << """
@@ -95,7 +95,7 @@ gatling { simulations = { include 'computerdatabase/BasicSimulation.scala' } }
         result = executeGradle("$GATLING_RUN_TASK_NAME")
         then:
         result.task(":compileGatlingScala").outcome == UP_TO_DATE
-        result.task(":$GATLING_RUN_TASK_NAME").outcome == UP_TO_DATE
+        result.task(":$GATLING_RUN_TASK_NAME").outcome == SUCCESS
 
         when: '3r time with changes'
         new File(new File(srcDir, "computerdatabase"), "BasicSimulation.scala") << """


### PR DESCRIPTION
Motivation:
Most users don't understand why their tests does not run when calling gatlingRun a second time in a row.

Modifications:
GatlingRun task is never up to date

Result:
We can launch simulation as many times in a row we want without weird arguments or specific configuration.