### PR TITLE
feat: delegate simulation classes discovery to commons and allow simulation start override, closes MISC-357

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-  implementation "io.gatling:gatling-enterprise-plugin-commons:1.0.3-M1"
+  implementation "io.gatling:gatling-enterprise-plugin-commons:1.1.1"
   implementation "org.apache.ant:ant:1.10.11"
 
   testImplementation('org.spockframework:spock-core:1.3-groovy-2.4') {

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
@@ -11,7 +11,7 @@ class GatlingEnterpriseUploadTask extends DefaultTask {
     @TaskAction
     void publish() {
         def gatling = project.extensions.getByType(GatlingPluginExtension)
-        gatling.enterprise.initEnterprisePlugin(project.version.toString(), logger).withCloseable {
+        gatling.enterprise.initBatchEnterprisePlugin(project.version.toString(), logger).withCloseable {
             if (gatling.enterprise.packageId) {
                 logger.lifecycle("Uploading package with packageId " + gatling.enterprise.packageId)
                 it.uploadPackage(gatling.enterprise.packageId, inputs.files.singleFile)

--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -1,7 +1,7 @@
 package io.gatling.gradle
 
-import io.gatling.plugin.EnterprisePlugin
-import io.gatling.plugin.EnterprisePluginClient
+import io.gatling.plugin.BatchEnterprisePlugin
+import io.gatling.plugin.BatchEnterprisePluginClient
 import io.gatling.plugin.InteractiveEnterprisePlugin
 import io.gatling.plugin.InteractiveEnterprisePluginClient
 import io.gatling.plugin.client.EnterpriseClient
@@ -184,7 +184,7 @@ class GatlingPluginExtension implements JvmConfigurable {
             }
 
             try {
-                return OkHttpEnterpriseClient.getInstance(getApiUrl(), getApiToken(), PLUGIN_NAME, version)
+                return new OkHttpEnterpriseClient(getApiUrl(), getApiToken(), PLUGIN_NAME, version)
             } catch (UnsupportedClientException e) {
                 throw new InvalidUserDataException(
                     "Please update the Gatling Gradle plugin to the latest version for compatibility with Gatling Enterprise. See https://gatling.io/docs/gatling/reference/current/extensions/gradle_plugin/ for more information about this plugin.",
@@ -192,8 +192,8 @@ class GatlingPluginExtension implements JvmConfigurable {
             }
         }
 
-        EnterprisePlugin initEnterprisePlugin(String version, Logger logger) {
-            return new EnterprisePluginClient(initEnterpriseClient(version), new GradlePluginIO(logger).logger)
+        BatchEnterprisePlugin initBatchEnterprisePlugin(String version, Logger logger) {
+            return new BatchEnterprisePluginClient(initEnterpriseClient(version), new GradlePluginIO(logger).logger)
         }
 
         InteractiveEnterprisePlugin initInteractiveEnterprisePlugin(String version, Logger logger) {

--- a/src/test/groovy/unit/GatlingRunTaskTest.groovy
+++ b/src/test/groovy/unit/GatlingRunTaskTest.groovy
@@ -3,7 +3,6 @@ package unit
 import io.gatling.gradle.GatlingPluginExtension
 import helper.GatlingUnitSpec
 import io.gatling.gradle.GatlingRunTask
-import io.gatling.gradle.SimulationFilesUtils
 import org.codehaus.groovy.runtime.typehandling.GroovyCastException
 import spock.lang.Unroll
 


### PR DESCRIPTION
**Motivation:**
Allow to start a simulation configured with a non-discovered class name,
by overriding the value based on plugin configuration or by client
input.

**Modifications:**
* Delegate simulations discovery to commons library
* Pass configured class name along redefined commons method signatures
* Handle introduced exceptions
* Take advantage of common interface between batch and interactive enterprise plugin