### PR TITLE
feat: handle unsupported version exception, closes MISC-374

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-  implementation "io.gatling:gatling-enterprise-plugin-commons:1.1.1"
+  implementation "io.gatling:gatling-enterprise-plugin-commons:1.1.2"
   implementation "org.apache.ant:ant:1.10.11"
 
   testImplementation('org.spockframework:spock-core:1.3-groovy-2.4') {

--- a/src/main/groovy/io/gatling/gradle/CommonLogMessage.groovy
+++ b/src/main/groovy/io/gatling/gradle/CommonLogMessage.groovy
@@ -1,0 +1,23 @@
+package io.gatling.gradle
+
+import io.gatling.plugin.model.Simulation
+import org.gradle.api.logging.Logger
+
+
+class CommonLogMessage {
+
+    static void logSimulationCreated(Simulation simulation, Logger logger) {
+        logger.lifecycle("Created simulation named ${simulation.name} with ID '${simulation.id}'")
+    }
+
+    static void logSimulationConfiguration(Simulation simulation, Logger logger) {
+        logger.lifecycle("""
+           |To start directly the same simulation, add the following Gradle configuration:
+           |gatling.enterprise.simulationId "${simulation.id}"
+           |gatling.enterprispackageId "${simulation.pkgId}"
+           |Or specify -Dgatling.enterprissimulationId=${simulation.id} -Dgatling.enterprispackageId=${simulation.pkgId}
+           |
+           |See https://gatling.io/docs/gatling/reference/current/extensions/gradle_plugin/#working-with-gatling-enterprise-cloud for more information.
+           |""".stripMargin())
+    }
+}

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseStartTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseStartTask.groovy
@@ -1,15 +1,10 @@
 package io.gatling.gradle
 
-import io.gatling.plugin.exceptions.SeveralSimulationClassNamesFoundException
-import io.gatling.plugin.exceptions.SeveralTeamsFoundException
-import io.gatling.plugin.exceptions.SimulationStartException
-import io.gatling.plugin.exceptions.UserQuitException
-import io.gatling.plugin.model.Simulation
-import org.gradle.api.BuildCancelledException
+import io.gatling.plugin.EnterprisePlugin
+import io.gatling.plugin.model.SimulationStartResult
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.TaskExecutionException
 
 @CacheableTask
 class GatlingEnterpriseStartTask extends DefaultTask {
@@ -27,75 +22,28 @@ class GatlingEnterpriseStartTask extends DefaultTask {
         final String artifactId = project.name
         final UUID packageId = gatling.enterprise.packageId
 
-        try {
-            def enterprisePlugin =
-                gatling.enterprise.batchMode ?
-                    gatling.enterprise.initBatchEnterprisePlugin(version, logger) :
-                    gatling.enterprise.initInteractiveEnterprisePlugin(version, logger)
+        final EnterprisePlugin enterprisePlugin =
+            gatling.enterprise.batchMode ?
+                gatling.enterprise.initBatchEnterprisePlugin(version, logger) :
+                gatling.enterprise.initInteractiveEnterprisePlugin(version, logger)
 
-            def simulationStartResult = gatling.enterprise.simulationId ?
-                enterprisePlugin.uploadPackageAndStartSimulation(simulationId, systemProperties, simulationClass, file) :
-                enterprisePlugin.createAndStartSimulation(teamId, groupId, artifactId, simulationClass, packageId, systemProperties, file)
+        final SimulationStartResult simulationStartResult = RecoverEnterprisePluginException.handle(logger) {
+            gatling.enterprise.simulationId ?
+                    enterprisePlugin.uploadPackageAndStartSimulation(simulationId, systemProperties, simulationClass, file) :
+                    enterprisePlugin.createAndStartSimulation(teamId, groupId, artifactId, simulationClass, packageId, systemProperties, file)
+        }
 
-            if (simulationStartResult.createdSimulation) {
-                logCreatedSimulation(simulationStartResult.simulation)
-            }
+        if (simulationStartResult.createdSimulation) {
+            CommonLogMessage.logSimulationCreated(simulationStartResult.simulation, logger)
+        }
 
-            if (simulationId == null) {
-                logSimulationConfiguration(simulationStartResult.simulation)
-            }
+        if (simulationId == null) {
+            CommonLogMessage.logSimulationConfiguration(simulationStartResult.simulation, logger)
+        }
 
-            logger.lifecycle("""
+        logger.lifecycle("""
                          |Simulation ${simulationStartResult.simulation.name} successfully started.
                          |Once running, reports will be available at: ${gatling.enterprise.url.toExternalForm() + simulationStartResult.runSummary.reportsPath}
                          |""".stripMargin())
-        } catch (UserQuitException e) {
-            throw new BuildCancelledException(e.getMessage(), e)
-        } catch (SeveralTeamsFoundException e) {
-            final String teams = e.getAvailableTeams().collect { String.format("- %s (%s)\n", it.id, it.name) }.join()
-            final String teamExample = e.getAvailableTeams().head().id.toString()
-            throwTaskExecutionException("""
-                |More than 1 team were found while creating a simulation.
-                |Available teams:
-                |${teams}
-                |Specify the team you want to use by adding this configuration to your build.gradle, e.g.:
-                |gatling.enterprise.teamId "${teamExample}"
-                |Or specify -Dgatling.enterprise.teamId= on the command
-                |
-                |See https://gatling.io/docs/gatling/reference/current/extensions/gradle_plugin/#working-with-gatling-enterprise-cloud for more information.
-                """.stripMargin())
-        } catch (SeveralSimulationClassNamesFoundException e) {
-            throwTaskExecutionException("""Several simulation classes were found
-             |${e.availableSimulationClassNames.map { name -> "- " + name }.mkString("\n")}
-             |Specify the simulation you want to use by adding this configuration to your build.gradle, e.g.:
-             |gatling.enterprise.teamId ${e.availableSimulationClassNames.head()}
-             |Or specify -Dgatling.enterprise.simulationClass=<className> on the command
-             |""".stripMargin())
-        } catch (SimulationStartException e) {
-            if (e.created) {
-                logCreatedSimulation(e.simulation)
-            }
-            logSimulationConfiguration(e.simulation)
-            throw e.getCause()
-        }
-    }
-
-    private void throwTaskExecutionException(String message) {
-        throw new TaskExecutionException(this, new IllegalArgumentException(message))
-    }
-
-    private void logCreatedSimulation(Simulation simulation) {
-        logger.lifecycle("Created simulation named ${simulation.name} with ID '${simulation.id}'")
-    }
-
-    private void logSimulationConfiguration(Simulation simulation) {
-        logger.lifecycle("""
-           |To start directly the same simulation, add the following Gradle configuration:
-           |gatling.enterprise.simulationId "${simulation.id}"
-           |gatling.enterprispackageId "${simulation.pkgId}"
-           |Or specify -Dgatling.enterprissimulationId=${simulation.id} -Dgatling.enterprispackageId=${simulation.pkgId}
-           |
-           |See https://gatling.io/docs/gatling/reference/current/extensions/gradle_plugin/#working-with-gatling-enterprise-cloud for more information.
-           |""".stripMargin())
     }
 }

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
@@ -11,17 +11,19 @@ class GatlingEnterpriseUploadTask extends DefaultTask {
     @TaskAction
     void publish() {
         def gatling = project.extensions.getByType(GatlingPluginExtension)
-        gatling.enterprise.initBatchEnterprisePlugin(project.version.toString(), logger).withCloseable {
-            if (gatling.enterprise.packageId) {
-                logger.lifecycle("Uploading package with packageId " + gatling.enterprise.packageId)
-                it.uploadPackage(gatling.enterprise.packageId, inputs.files.singleFile)
-            } else if (gatling.enterprise.simulationId) {
-                logger.lifecycle("Uploading package belonging to the simulation " + gatling.enterprise.simulationId)
-                it.uploadPackageWithSimulationId(gatling.enterprise.simulationId, inputs.files.singleFile)
-            } else {
-                throw new InvalidUserDataException("You need to either configure gatling.enterprise.packageId (or pass it with '-Dgatling.enterprise.packageId=<PACKAGE_ID>') " +
-                    "or gatling.enterprise.simulation (or pass it with '-Dgatling.enterprise.simulationId=<SIMULATION_ID>') to upload a package." +
-                    "Please see https://gatling.io/docs/gatling/reference/current/extensions/gradle_plugin/#working-with-gatling-enterprise-cloud for more information.")
+        RecoverEnterprisePluginException.handle(logger) {
+            gatling.enterprise.initBatchEnterprisePlugin(project.version.toString(), logger).withCloseable {
+                if (gatling.enterprise.packageId) {
+                    logger.lifecycle("Uploading package with packageId " + gatling.enterprise.packageId)
+                    it.uploadPackage(gatling.enterprise.packageId, inputs.files.singleFile)
+                } else if (gatling.enterprise.simulationId) {
+                    logger.lifecycle("Uploading package belonging to the simulation " + gatling.enterprise.simulationId)
+                    it.uploadPackageWithSimulationId(gatling.enterprise.simulationId, inputs.files.singleFile)
+                } else {
+                    throw new InvalidUserDataException("You need to either configure gatling.enterprise.packageId (or pass it with '-Dgatling.enterprise.packageId=<PACKAGE_ID>') " +
+                        "or gatling.enterprise.simulation (or pass it with '-Dgatling.enterprise.simulationId=<SIMULATION_ID>') to upload a package." +
+                        "Please see https://gatling.io/docs/gatling/reference/current/extensions/gradle_plugin/#working-with-gatling-enterprise-cloud for more information.")
+                }
             }
         }
     }

--- a/src/main/groovy/io/gatling/gradle/RecoverEnterprisePluginException.groovy
+++ b/src/main/groovy/io/gatling/gradle/RecoverEnterprisePluginException.groovy
@@ -1,0 +1,55 @@
+package io.gatling.gradle
+
+
+import io.gatling.plugin.exceptions.*
+import org.gradle.api.BuildCancelledException
+import org.gradle.api.Task
+import org.gradle.api.logging.Logger
+import org.gradle.api.tasks.TaskExecutionException
+
+class RecoverEnterprisePluginException {
+
+    /**
+     * @param f Closure defined inside a Task
+     * @param logger used to report EnterprisePluginException
+     * @return closure result
+     */
+    static <R> R handle(Logger logger, Closure<R> f) {
+        try {
+            return f.doCall()
+        }  catch (UserQuitException e) {
+            throw new BuildCancelledException(e.getMessage(), e)
+        } catch (SeveralTeamsFoundException e) {
+            final String teams = e.getAvailableTeams().collect { String.format("- %s (%s)\n", it.id, it.name) }.join()
+            final String teamExample = e.getAvailableTeams().head().id.toString()
+            throwTaskExecutionException(f.getThisObject(), """
+                |More than 1 team were found while creating a simulation.
+                |Available teams:
+                |${teams}
+                |Specify the team you want to use by adding this configuration to your build.gradle, e.g.:
+                |gatling.enterprise.teamId "${teamExample}"
+                |Or specify -Dgatling.enterprise.teamId= on the command
+                |
+                |See https://gatling.io/docs/gatling/reference/current/extensions/gradle_plugin/#working-with-gatling-enterprise-cloud for more information.
+                """.stripMargin())
+        } catch (SeveralSimulationClassNamesFoundException e) {
+            throwTaskExecutionException(f.getThisObject(), """Several simulation classes were found
+             |${e.availableSimulationClassNames.map { name -> "- " + name }.mkString("\n")}
+             |Specify the simulation you want to use by adding this configuration to your build.gradle, e.g.:
+             |gatling.enterprise.teamId ${e.availableSimulationClassNames.head()}
+             |Or specify -Dgatling.enterprise.simulationClass=<className> on the command
+             |""".stripMargin())
+        } catch (SimulationStartException e) {
+            if (e.created) {
+                CommonLogMessage.logSimulationCreated(e.simulation, logger)
+            }
+            CommonLogMessage.logSimulationConfiguration(e.simulation, logger)
+            throw e.getCause()
+        }
+    }
+
+    private static void throwTaskExecutionException(Object subject, String message) throws TaskExecutionException {
+        throw new TaskExecutionException(subject as Task, new IllegalArgumentException(message))
+    }
+
+}

--- a/src/main/groovy/io/gatling/gradle/RecoverEnterprisePluginException.groovy
+++ b/src/main/groovy/io/gatling/gradle/RecoverEnterprisePluginException.groovy
@@ -19,6 +19,12 @@ class RecoverEnterprisePluginException {
             return f.doCall()
         }  catch (UserQuitException e) {
             throw new BuildCancelledException(e.getMessage(), e)
+        } catch (UnsupportedJavaVersionException e) {
+            throwTaskExecutionException(f.getThisObject(), """
+                |${e.getMessage()}
+                |In order to target the supported Java bytecode version, please configure targetCompatibility to Java ${e.supportedVersion} in your build configuration. (see https://docs.gradle.org/current/userguide/java_plugin.html#sec:java-extension)
+                |Or, reported class may come from your project dependencies, published targeting Java ${e.version}.
+                """.stripMargin())
         } catch (SeveralTeamsFoundException e) {
             final String teams = e.getAvailableTeams().collect { String.format("- %s (%s)\n", it.id, it.name) }.join()
             final String teamExample = e.getAvailableTeams().head().id.toString()


### PR DESCRIPTION
chore: centralize plugin exception handling accross tasks
---

**Motivation:**
Recovering from error is always the same

**Modification:**
Add RecoverEnterprisePluginException to extend in order to get recovering method

 
feat: handle unsupported version exception, closes MISC-374
---

**Motivation:**
New commons version throw `UnsupportedJavaVersionException` when java version isn't supported by Gatling Enterprise CLoud

**Modification:**
Log exception message, along java option to target a compatible bytecode.