### PR TITLE
feat: remove automatic maven central configuration, #4259

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -225,15 +225,13 @@ class GatlingPlugin implements Plugin<Project> {
                 }
             }
 
-            if (shouldAddMavenCentral(evaluatedProject)) {
-                evaluatedProject.repositories {
-                    mavenCentral(name: "gatlingMavenCentral")
-                }
+            if (isMissGatlingDependency(evaluatedProject)) {
+                throw new GradleException("""Gatling dependencies cannot be found with your current configuration. Please add a repository (ex: mavenCentral : https://docs.gradle.org/current/userguide/declaring_repositories.html#sub:maven_central )""")
             }
         }
     }
 
-    private static boolean shouldAddMavenCentral(Project project) {
+    private static boolean isMissGatlingDependency(Project project) {
 
         if (!project.repositories.isEmpty()) {
             // there are declared repositories, let's try to resolve gatling configuration

--- a/src/test/groovy/func/WhenCompileSimulationSpec.groovy
+++ b/src/test/groovy/func/WhenCompileSimulationSpec.groovy
@@ -55,6 +55,10 @@ class WhenCompileSimulationSpec extends GatlingFuncSpec {
         given:
         buildFile.text = """
 plugins { id 'io.gatling.gradle' }
+
+repositories {
+  mavenCentral()
+}
 """
         when:
         executeGradle(GATLING_CLASSES_TASK_NAME)

--- a/src/test/groovy/helper/GatlingSpec.groovy
+++ b/src/test/groovy/helper/GatlingSpec.groovy
@@ -27,7 +27,14 @@ abstract class GatlingSpec extends Specification {
     def generateBuildScripts() {
         buildFile = projectDir.newFile("build.gradle")
         buildFile.text = """
-plugins { id 'io.gatling.gradle' }
+plugins {
+  id 'io.gatling.gradle'
+}
+
+repositories {
+    mavenCentral()
+}
+
 dependencies {
   gatling group: 'commons-lang', name: 'commons-lang', version: '2.6'
   gatling group: 'org.json4s', name: 'json4s-jackson_2.13', version: '3.6.10'
@@ -41,6 +48,11 @@ dependencies {
 plugins {
   id("io.gatling.gradle")
 }
+
+repositories {
+    mavenCentral()
+}
+
 dependencies {
   gatling("commons-lang:commons-lang:2.6")
   gatling("org.json4s:json4s-jackson_2.13:3.6.10")

--- a/src/test/groovy/helper/GatlingUnitSpec.groovy
+++ b/src/test/groovy/helper/GatlingUnitSpec.groovy
@@ -17,6 +17,7 @@ abstract class GatlingUnitSpec extends GatlingSpec {
 
         project = ProjectBuilder.builder().withProjectDir(projectDir.root).build()
         project.pluginManager.apply 'io.gatling.gradle'
+        project.repositories { mavenCentral(name: "gatlingMavenCentral") }
 
         gatlingExt = project.extensions.getByType(GatlingPluginExtension)
     }


### PR DESCRIPTION
Motivation:
Flaky tests and out of scope feature

Modifications:
 * Remove automatic maven central configuration
 * Display an explicit message when gatling dependencies are not reachable

Result:
Limit scope

Closes gatling/gatling#4259