### PR TITLE
Improve error message in case of Java version error

### DIFF
--- a/src/main/groovy/io/gatling/gradle/RecoverEnterprisePluginException.groovy
+++ b/src/main/groovy/io/gatling/gradle/RecoverEnterprisePluginException.groovy
@@ -22,8 +22,13 @@ class RecoverEnterprisePluginException {
         } catch (UnsupportedJavaVersionException e) {
             throwTaskExecutionException(f.getThisObject(), """
                 |${e.getMessage()}
-                |In order to target the supported Java bytecode version, please configure targetCompatibility to Java ${e.supportedVersion} in your build configuration. (see https://docs.gradle.org/current/userguide/java_plugin.html#sec:java-extension)
-                |Or, reported class may come from your project dependencies, published targeting Java ${e.version}.
+                |In order to target the supported Java version, please use the following Gradle setting (requires Gradle 6.6 or later):
+                |compileJava {
+                |    options.release = ${e.supportedVersion}
+                |}
+                |See also the Gradle documentation: https://docs.gradle.org/current/userguide/building_java_projects.html#sec:java_cross_compilation
+                |Another solution is to configure a Java toolchain to use Java ${e.supportedVersion}; see https://docs.gradle.org/current/userguide/toolchains.html
+                |Alternatively, the reported class may come from your project's dependencies, published targeting Java ${e.version}. In this case you need to use dependencies which target Java ${e.supportedVersion} or lower."
                 """.stripMargin())
         } catch (SeveralTeamsFoundException e) {
             final String teams = e.getAvailableTeams().collect { String.format("- %s (%s)\n", it.id, it.name) }.join()


### PR DESCRIPTION
ref: MISC-396

Motivation:
The error message in case of UnsupportedJavaVersionException is not clear enough

Modifications:
In case of UnsupportedJavaVersionException:
- give the full example of the setting to use
- suggest using the newer 'release' setting (available from JDK 10, and this will only apply to users on JDK 18+) rather than  'targetCompatibility'
- also link to the toolchain doc, that's another recommended way to deal with different Java versions on Gradle

Result:
Better information for the user in case of error.