### PR TITLE
chore: avoid cache corruption

### DIFF
--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -32,6 +32,5 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: check
-          wrapper-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true
+          # Disable cache because of corruption
+          cache-disabled: true


### PR DESCRIPTION
Motivation:
Builds fail day after day without notable causes.

Modifications:
* Remove obsolete arguments (only a common `cache-disabled` exists now)
* Disable cache

Result:
Avoid cache corruption