### PR TITLE
Bump Scala version

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -266,7 +266,7 @@ class GatlingPluginExtension implements JvmConfigurable {
 
     static final String GATLING_VERSION = '3.8.4'
 
-    static final String SCALA_VERSION = '2.13.8'
+    static final String SCALA_VERSION = '2.13.10'
 
     static final Closure DEFAULT_SIMULATIONS = { include("**/*Simulation*.java", "**/*Simulation*.kt", "**/*Simulation*.scala") }
 


### PR DESCRIPTION
Bumped default Scala version to match [Gatling core](https://github.com/gatling/gatling/blob/main/build.sbt). I know you can configure Scala version through the closure but there is a [ CVE present in 2.13.8](https://github.com/advisories/GHSA-8qv5-68g4-248j) which is being flagged in my downstream projects security scan without being overridden. Let me know if there are any questions.