### PR TITLE
Remove usage of deprecated import "org.gradle.util.VersionNumber"

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -5,8 +5,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.ProjectConfigurationException
 import org.gradle.api.plugins.scala.ScalaPlugin
-import org.gradle.util.GradleVersion
-import org.gradle.util.VersionNumber
+import org.gradle.util.GradleVersion;
 
 final class GatlingPlugin implements Plugin<Project> {
 
@@ -31,7 +30,7 @@ final class GatlingPlugin implements Plugin<Project> {
 
     void apply(Project project) {
 
-        if (VersionNumber.parse(GradleVersion.current().version).major < 5) {
+        if (GradleVersion.current() < GradleVersion.version("5.0")) {
             throw new GradleException("Current Gradle version (${GradleVersion.current().version}) is unsupported. Minimal supported version is 5.0")
         }
 


### PR DESCRIPTION
Since Gradle 7.6, we get a warning that this class will be removed in Gradle 9.0.
https://docs.gradle.org/current/javadoc/org/gradle/util/VersionNumber.html

![image](https://user-images.githubusercontent.com/9151470/204277097-e8dfb8f6-8d6d-48e0-a7cb-6150900d28d1.png)
