### PR TITLE
fix: crash immediately if not matching simulation class is found, close #4105

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingRunTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingRunTask.groovy
@@ -75,7 +75,12 @@ class GatlingRunTask extends DefaultTask {
     void gatlingRun() {
         def gatlingExt = project.extensions.getByType(GatlingPluginExtension)
 
-        Map<String, ExecResult> results = simulationFilesToFQN().collectEntries { String simulationClass ->
+        def resolvedSimulations = simulationFilesToFQN()
+        if (resolvedSimulations.isEmpty()) {
+            throw new IllegalArgumentException("No simulation matching 'simulations' closure found")
+        }
+
+        Map<String, ExecResult> results = resolvedSimulations.collectEntries { String simulationClass ->
             [(simulationClass): project.javaexec({ JavaExecSpec exec ->
                 exec.main = GatlingPluginExtension.GATLING_MAIN_CLASS
                 exec.classpath = project.configurations.gatlingRuntimeClasspath


### PR DESCRIPTION
Motivation:

We should crash early when no simulation is found, in particular when specifying one with `gatlingRun-FQCN`.