### PR TITLE
Stop adding scala-library to implementation, close gatling/gatling#4374

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -211,7 +211,6 @@ final class GatlingPlugin implements Plugin<Project> {
             evaluatedProject.dependencies {
                 def evaluatedExt = evaluatedProject.extensions.getByType(GatlingPluginExtension)
 
-                implementation "org.scala-lang:scala-library:${evaluatedExt.scalaVersion}"
                 gatlingImplementation "org.scala-lang:scala-library:${evaluatedExt.scalaVersion}"
                 gatling "io.gatling.highcharts:gatling-charts-highcharts:${evaluatedExt.gatlingVersion}"
 

--- a/src/test/groovy/unit/GatlingPluginTest.groovy
+++ b/src/test/groovy/unit/GatlingPluginTest.groovy
@@ -39,9 +39,6 @@ class GatlingPluginTest extends GatlingUnitSpec {
         project.configurations.getByName("gatlingImplementation").allDependencies.find {
             it.name == "scala-library" && it.version == GatlingPluginExtension.SCALA_VERSION
         }
-        project.configurations.getByName("implementation").allDependencies.find {
-            it.name == "scala-library" && it.version == GatlingPluginExtension.SCALA_VERSION
-        }
     }
 
     def "should allow overriding gatling version via extension"() {
@@ -73,9 +70,6 @@ class GatlingPluginTest extends GatlingUnitSpec {
         project.evaluate()
         then:
         project.configurations.getByName("gatlingImplementation").allDependencies.find {
-            it.name == "scala-library" && it.version == "2.11.3"
-        }
-        project.configurations.getByName("implementation").allDependencies.find {
             it.name == "scala-library" && it.version == "2.11.3"
         }
     }


### PR DESCRIPTION
Motivation:

We should only touch the gatling configs.

See https://community.gatling.io/t/scala-library-dependency-leaked/7495