### PR TITLE
Add Gradle 8.0 compatibility

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterprisePackageTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterprisePackageTask.groovy
@@ -55,8 +55,10 @@ class GatlingEnterprisePackageTask extends Jar {
 
     @Override
     protected CopyAction createCopyAction() {
+        // archivePath is deprecated starting with Gradle 5.2, but used for compatibility with Gradle 5.0+
+        File archiveFile = GradleUtils.isGradleFiveTwoOrNewer(project.gradle) ? getArchiveFile().get().asFile : getArchivePath()
         return new GatlingEnterpriseCopyAction(
-            getArchivePath(), // Deprecated starting with Gradle 5.2, but used for compatibility with Gradle 5.0+
+            archiveFile,
             getMetadataCharset(),
             getMainSpec().buildRootResolver().getPatternSet(),
             isPreserveFileTimestamps(),

--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -129,7 +129,11 @@ final class GatlingPlugin implements Plugin<Project> {
     GatlingEnterprisePackageTask createEnterprisePackageTask(Project project) {
         GatlingEnterprisePackageTask gatlingEnterprisePackage = project.tasks.create(name: ENTERPRISE_PACKAGE_TASK_NAME, type: GatlingEnterprisePackageTask)
 
-        gatlingEnterprisePackage.classifier = "tests"
+        if(GradleUtils.isGradleFiveTwoOrNewer(project.gradle)) {
+            gatlingEnterprisePackage.archiveClassifier.set("tests")
+        } else {
+            gatlingEnterprisePackage.classifier = "tests"
+        }
 
         gatlingEnterprisePackage.exclude(
             "module-info.class",

--- a/src/main/groovy/io/gatling/gradle/GradleUtils.groovy
+++ b/src/main/groovy/io/gatling/gradle/GradleUtils.groovy
@@ -1,0 +1,10 @@
+package io.gatling.gradle
+
+import org.gradle.api.invocation.Gradle
+import org.gradle.util.GradleVersion
+
+class GradleUtils {
+    static boolean isGradleFiveTwoOrNewer(Gradle gradle) {
+        return GradleVersion.current().baseVersion >= GradleVersion.version("5.2")
+    }
+}


### PR DESCRIPTION
Hi folks,

I found that this plugin is using deprecated Gradle APIs that are being removed in Gradle 8.0 which already has a RC1 out.

This change is to conditionally use the proper property in order to keep backwards compatibility to Gradle 5.0. 