### PR TITLE
Update GatlingPlugin to lazy load and configure tasks

### DIFF
--- a/src/test/groovy/func/GradleCompatibilitySpec.groovy
+++ b/src/test/groovy/func/GradleCompatibilitySpec.groovy
@@ -30,7 +30,7 @@ class GradleCompatibilitySpec extends GatlingFuncSpec {
     }
 
     @Unroll
-    void 'should fail for version #gradleVersion that is less than 5.0'() {
+    void 'should fail with friendly message for version #gradleVersion that is less than 5.0'() {
         given:
         prepareTest()
         when:
@@ -38,6 +38,18 @@ class GradleCompatibilitySpec extends GatlingFuncSpec {
         then:
         result.output.contains("Current Gradle version (${gradleVersion}) is unsupported. Minimal supported version is 5.0")
         where:
-        gradleVersion << ["4.0.1", "4.10.2", "3.5", "3.0", "2.9"]
+        gradleVersion << ["4.10.2"]
+    }
+
+    @Unroll
+    void 'should fail with exception for version #gradleVersion that is less than 4.10'() {
+        given:
+        prepareTest()
+        when:
+        BuildResult result = executeGradleTaskWithVersion('tasks', gradleVersion, true)
+        then:
+        result.output.contains("java.lang.ClassNotFoundException: org.gradle.api.tasks.TaskProvider")
+        where:
+        gradleVersion << ["4.0.1", "3.5", "3.0", "2.9"]
     }
 }

--- a/src/test/groovy/unit/GatlingPluginTest.groovy
+++ b/src/test/groovy/unit/GatlingPluginTest.groovy
@@ -5,6 +5,7 @@ import io.gatling.gradle.GatlingPluginExtension
 import io.gatling.gradle.GatlingRunTask
 import io.gatling.gradle.LogbackConfigTask
 import io.gatling.plugin.GatlingConstants
+import org.gradle.api.tasks.TaskProvider
 import org.gradle.language.jvm.tasks.ProcessResources
 
 import static io.gatling.gradle.GatlingPlugin.GATLING_LOGBACK_TASK_NAME
@@ -90,8 +91,10 @@ class GatlingPluginTest extends GatlingUnitSpec {
             it.simulations == null
             it.jvmArgs == null
             it.systemProperties == null
-            it.dependsOn.size() == 1 && it.dependsOn.first() instanceof Collection
-            it.dependsOn.first()*.name.sort() == ["gatlingClasses", "gatlingLogback"]
+            it.dependsOn.size() == 2
+            def taskNames = it.dependsOn.collect {TaskProvider element -> return element.name}
+            taskNames.contains("gatlingClasses")
+            taskNames.contains("gatlingLogback")
         }
     }
 


### PR DESCRIPTION
Update GatlingPlugin to lazy load and configure tasks

## Motivation

When using the Gatling Gradle plugin in conjunction with Gradle Enterprise, the build scan identified that the Gatling plugin was eagerly loading tasks into the task graph when they did not need to be. This slows down large builds with hundreds of modules and tens of thousands of tasks. Since Gradle 5.0 the concept of [task configuration avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html) was added. This helps speed up builds by only registering tasks when they are needed. This commit updates the Gatling plugin to use task configuration avoidance.

![SCR-20230206-grt](https://user-images.githubusercontent.com/468163/217036975-fbbcd0e1-f65a-4f0f-aaee-8299269fc715.png)

## Modifications

Moving to task configuration avoidance is fairly straightforward. There is a guide in the [documentation](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html). All instances of the create() method were changed to the corresponding register() method. Where appropriate configuration was moved inside the Action lambda to facilitate the lazy configuration pattern. Where tasks were being fetched by name the call site was changed to the named() method instead. Tests were updated to correspond to these changes.

## Result

The result is a Gradle plugin that leverages task configuration avoidance improving build times. The plugin remains compatible with Gradle 5.0 and above.