### PR TITLE
feat: Add ability to monitor progress and wait for run end for enterpriseStart

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-  implementation "io.gatling:gatling-enterprise-plugin-commons:1.4.12"
+  implementation "io.gatling:gatling-enterprise-plugin-commons:1.5.1"
   implementation "org.apache.ant:ant:1.10.11"
 
   testImplementation('org.spockframework:spock-core:1.3-groovy-2.4') {

--- a/src/main/groovy/io/gatling/gradle/CommonLogMessage.groovy
+++ b/src/main/groovy/io/gatling/gradle/CommonLogMessage.groovy
@@ -10,14 +10,29 @@ final class CommonLogMessage {
         logger.lifecycle("Created simulation named ${simulation.name} with ID '${simulation.id}'")
     }
 
-    static void logSimulationConfiguration(Simulation simulation, Logger logger) {
-        logger.lifecycle("""
-           |To start directly the same simulation, add the following Gradle configuration:
-           |gatling.enterprise.simulationId "${simulation.id}"
-           |gatling.enterprispackageId "${simulation.pkgId}"
-           |Or specify -Dgatling.enterprissimulationId=${simulation.id} -Dgatling.enterprispackageId=${simulation.pkgId}
-           |
-           |See https://gatling.io/docs/gatling/reference/current/extensions/gradle_plugin/#working-with-gatling-enterprise-cloud for more information.
-           |""".stripMargin())
+    static void logSimulationConfiguration(Logger logger, Simulation simulation, UUID simulationIdSetting, boolean waitForRunEndSetting) {
+        if (simulationIdSetting == null || !waitForRunEndSetting) {
+            StringBuilder builder = new StringBuilder("\n")
+            if (simulationIdSetting == null) {
+                builder.append(
+                    """To start directly the same simulation, add the following Gradle configuration:
+                      |gatling.enterprise.simulationId "${simulation.id}"
+                      |gatling.enterprispackageId "${simulation.pkgId}"
+                      |Or specify -Dgatling.enterprissimulationId=${simulation.id} -Dgatling.enterprispackageId=${simulation.pkgId}
+                      |
+                      |""".stripMargin()
+                )
+            }
+            if (!waitForRunEndSetting) {
+                builder.append(
+                    """To wait for the end of the run when starting a simulation on Gatling Enterprise, add the following configuration:
+                      |gatling.enterprise.waitForRunEnd true
+                      |Or specify -Dgatling.enterprise.waitForRunEnd=true
+                      |
+                      |""".stripMargin())
+            }
+            builder.append("See https://gatling.io/docs/gatling/reference/current/extensions/gradle_plugin/#working-with-gatling-enterprise-cloud for more information.\n")
+            logger.lifecycle(builder.toString())
+        }
     }
 }

--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -26,6 +26,7 @@ class GatlingPluginExtension {
     private static final String BATCH_MODE_PROPERTY = "gatling.enterprise.batchMode"
     private static final String SYSTEM_PROPS_PROPERTY = "gatling.enterprise.systemProps"
     private static final String ENVIRONMENT_VARIABLES_PROPERTY = "gatling.enterprise.environmentVariables"
+    private static final String WAIT_FOR_RUN_END_PROPERTY = "gatling.enterprise.waitForRunEnd"
     private static final String PLUGIN_NAME = "gatling-gradle-plugin"
 
     final static class Enterprise {
@@ -40,6 +41,7 @@ class GatlingPluginExtension {
         private URL url = new URL("https://cloud.gatling.io")
         private String simulationClass
         private boolean batchMode
+        private boolean waitForRunEnd
 
         def setBatchMode(boolean batchMode) {
             this.batchMode = batchMode
@@ -129,6 +131,14 @@ class GatlingPluginExtension {
             setSimulationClass(simulationClass)
         }
 
+        def setWaitForRunEnd(boolean waitForRunEnd) {
+            this.waitForRunEnd = waitForRunEnd
+        }
+
+        def waitForRunEnd(boolean waitForRunEnd) {
+            setWaitForRunEnd(waitForRunEnd)
+        }
+
         @Input
         @Optional
         UUID getSimulationId() {
@@ -207,12 +217,13 @@ class GatlingPluginExtension {
         @Input
         @Optional
         boolean getBatchMode() {
-            if (batchMode) {
-                return batchMode
-            } else {
-                def systemBatchMode = System.getProperty(BATCH_MODE_PROPERTY)
-                return systemBatchMode ? Boolean.parseBoolean(systemBatchMode) : false
-            }
+            return batchMode || Boolean.getBoolean(BATCH_MODE_PROPERTY)
+        }
+
+        @Input
+        @Optional
+        boolean getWaitForRunEnd() {
+            return waitForRunEnd || Boolean.getBoolean(WAIT_FOR_RUN_END_PROPERTY)
         }
 
         EnterpriseClient initEnterpriseClient(String version) {


### PR DESCRIPTION
Configuration example in the `build.gradle`:

```groovy
gatling {
    enterprise {
        waitForRunEnd true // or waitForRunEnd = true
    }
}
```

or run with e.g. `./gradlew gatlingEnterpriseStart -Dgatling.enterprise.waitForRunEnd=true`