### PR TITLE
fix: LogbackConfigTask crash on Gradle 7.0 to 7.4, close gatling/gatling#4394

### DIFF
--- a/src/main/groovy/io/gatling/gradle/LogbackConfigTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/LogbackConfigTask.groovy
@@ -3,6 +3,7 @@ package io.gatling.gradle
 import org.gradle.api.DefaultTask
 import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
@@ -35,6 +36,7 @@ class LogbackConfigTask extends DefaultTask {
 </configuration>"""
     }
 
+    @Internal
     private Logger logger
 
     /** Used for testing purposes. Was available on the DefaultTask up to Gradle 6.6. */


### PR DESCRIPTION
Motivation:

On Gradle 7.0 to 7.4, the property annotation analysis fails for our task LogbackConfigTask because the logger property isn't annotated as input, output, or internal.

Modifications:

- Annotate LogbackConfigTask#logger as internal
- Add test with several Gradle versions in WhenRunSimulationSpec