### PR TITLE
fix: LogbackConfigTask crash on some Gradle 5.x/6.x versions

### DIFF
--- a/src/main/groovy/io/gatling/gradle/LogbackConfigTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/LogbackConfigTask.groovy
@@ -1,9 +1,7 @@
 package io.gatling.gradle
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.logging.Logger
 import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.TaskAction
@@ -34,19 +32,6 @@ class LogbackConfigTask extends DefaultTask {
        <appender-ref ref="CONSOLE" />
     </root>
 </configuration>"""
-    }
-
-    @Internal
-    private Logger logger
-
-    /** Used for testing purposes. Was available on the DefaultTask up to Gradle 6.6. */
-    void replaceLogger(Logger logger) {
-        this.logger = logger
-    }
-
-    @Override
-    Logger getLogger() {
-        return this.logger ?: super.getLogger()
     }
 
     @InputFiles

--- a/src/test/groovy/func/WhenRunSimulationSpec.groovy
+++ b/src/test/groovy/func/WhenRunSimulationSpec.groovy
@@ -30,8 +30,7 @@ class WhenRunSimulationSpec extends GatlingFuncSpec {
         and: "logs doesn't contain INFO"
         !result.output.split().any { it.contains("INFO") }
         where:
-        // TODO fix stack overflow error on Gradle 5.6.4/6.0/6.3/6.4.1; then replace versions list with SUPPORTED_GRADLE_VERSIONS constant
-        gradleVersion << ["5.0", "6.9.1", "7.0", "7.6", "8.0"]
+        gradleVersion << SUPPORTED_GRADLE_VERSIONS
     }
 
     def "should execute only #simulation when initiated by rule"() {

--- a/src/test/groovy/unit/LogbackConfigTaskTest.groovy
+++ b/src/test/groovy/unit/LogbackConfigTaskTest.groovy
@@ -6,7 +6,7 @@ import io.gatling.gradle.GatlingPluginExtension
 import io.gatling.gradle.LogHttp
 import io.gatling.gradle.LogbackConfigTask
 import org.apache.commons.io.FileUtils
-import org.gradle.api.logging.Logger
+import org.gradle.internal.logging.slf4j.ContextAwareTaskLogger
 import spock.lang.Unroll
 
 import static io.gatling.gradle.GatlingPlugin.GATLING_LOGBACK_TASK_NAME
@@ -31,7 +31,9 @@ class LogbackConfigTaskTest extends GatlingUnitSpec {
 
     def setup() {
         theTask = project.tasks.getByName(GATLING_LOGBACK_TASK_NAME) as LogbackConfigTask
-        theTask.replaceLogger(Mock(Logger))
+        def loggerField = org.gradle.api.internal.AbstractTask.class.getDeclaredField("logger")
+        loggerField.accessible = true
+        loggerField.set(theTask, Mock(ContextAwareTaskLogger))
         logbackConfig = LogbackConfigTask.logbackFile(this.project.buildDir)
     }
 


### PR DESCRIPTION
Motivation:

Currently, LogbackConfigTask crashes on some Gradle versions (crashes on 5.6.4 and 6.4.1, but works on 5.0 or 6.9.1). On those versions, calling LogbackConfigTask#getLogger() leads to an infinite recursive call and a stack overflow error.

Modifications:

- The getLogger override on LogbackConfigTask is only needed for the tests in LogbackConfigTaskTest, so we can cimply remove it without affecting production code.
- In LogbackConfigTaskTest, use reflection to set the private logger field defined in a parent class.
- Add the previously failing Gradle versions to a test in WhenRunSimulationSpec

Result:

- We still need a hack to mock the logger in LogbackConfigTaskTest, but now it's only in the test code, not in the production code
- The plugin works again on the Gradle versions which were affected, e.g. 5.6.4 or 6.4.1

-----

The `getLogger` override was introduced in #73 to re-implement the `replaceLogger` method, which was removed after Gradle 6.6, so that we could upgrade the Gradle version in our build. But instead we can just do what the old `replaceLogger` method used to do using reflection in the test code - this way we don't introduce a hack in the production code itself. That being said, I still don't understand why the call to `super.getLogger()` was messed up on some Gradle versions... But this removes the question entirely.