### PR TITLE
replace deprecated -target with -release jdk version

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -196,7 +196,7 @@ final class GatlingPlugin implements Plugin<Project> {
         project.tasks.named("compileGatlingScala").configure {
             scalaCompileOptions.with {
                 additionalParameters = [
-                    "-target:jvm-1.8",
+                    "-release:8",
                     "-deprecation",
                     "-feature",
                     "-unchecked",

--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -196,7 +196,6 @@ final class GatlingPlugin implements Plugin<Project> {
         project.tasks.named("compileGatlingScala").configure {
             scalaCompileOptions.with {
                 additionalParameters = [
-                    "-release:8",
                     "-deprecation",
                     "-feature",
                     "-unchecked",


### PR DESCRIPTION
I get this warning
```
compileGatlingScala
[Warn] : -target is deprecated: Use -release instead to compile against the correct platform API.
```

I hope this fixes it.

See 
https://docs.scala-lang.org/overviews/compiler-options/index.html
https://docs.gradle.org/current/userguide/upgrading_version_7.html#scala_compilation_target
https://docs.gradle.org/8.1.1/userguide/scala_plugin.html#sec:scala_target
