### PR TITLE
chore: remove "private" prefix from control plane config

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -27,7 +27,7 @@ class GatlingPluginExtension {
     private static final String SYSTEM_PROPS_PROPERTY = "gatling.enterprise.systemProps"
     private static final String ENVIRONMENT_VARIABLES_PROPERTY = "gatling.enterprise.environmentVariables"
     private static final String WAIT_FOR_RUN_END_PROPERTY = "gatling.enterprise.waitForRunEnd"
-    private static final String PRIVATE_CONTROL_PLANE_URL = "gatling.enterprise.privateControlPlaneUrl"
+    private static final String CONTROL_PLANE_URL = "gatling.enterprise.controlPlaneUrl"
     private static final String PLUGIN_NAME = "gatling-gradle-plugin"
 
     final static class Enterprise {
@@ -43,7 +43,7 @@ class GatlingPluginExtension {
         private String simulationClass
         private boolean batchMode
         private boolean waitForRunEnd
-        private URL privateControlPlaneUrl
+        private URL controlPlaneUrl
 
         def setBatchMode(boolean batchMode) {
             this.batchMode = batchMode
@@ -141,12 +141,12 @@ class GatlingPluginExtension {
             setWaitForRunEnd(waitForRunEnd)
         }
 
-        def setPrivateControlPlaneUrl(String privateControlPlaneUrl) {
-            this.privateControlPlaneUrl = new URL(privateControlPlaneUrl)
+        def setControlPlaneUrl(String controlPlaneUrl) {
+            this.controlPlaneUrl = new URL(controlPlaneUrl)
         }
 
-        def privateControlPlaneUrl(String privateControlPlaneUrl) {
-            setPrivateControlPlaneUrl(privateControlPlaneUrl)
+        def controlPlaneUrl(String controlPlaneUrl) {
+            setControlPlaneUrl(controlPlaneUrl)
         }
 
         @Input
@@ -238,8 +238,8 @@ class GatlingPluginExtension {
 
         @Input
         @Optional
-        URL getprivateControlPlaneUrl() {
-            return privateControlPlaneUrl ?: new URL(System.getProperty(PRIVATE_CONTROL_PLANE_URL))
+        URL getControlPlaneUrl() {
+            return controlPlaneUrl ?: new URL(System.getProperty(CONTROL_PLANE_URL))
         }
 
         EnterpriseClient initEnterpriseClient(String version) {
@@ -255,7 +255,7 @@ class GatlingPluginExtension {
             }
 
             try {
-                return new HttpEnterpriseClient(getUrl(), getApiToken(), PLUGIN_NAME, version, getprivateControlPlaneUrl())
+                return new HttpEnterpriseClient(getUrl(), getApiToken(), PLUGIN_NAME, version, getControlPlaneUrl())
             } catch (UnsupportedClientException e) {
                 throw new InvalidUserDataException(
                     "Please update the Gatling Gradle plugin to the latest version for compatibility with Gatling Enterprise. See https://gatling.io/docs/gatling/reference/current/extensions/gradle_plugin/ for more information about this plugin.",


### PR DESCRIPTION
Motivation:
Our users doesn't know about private or public control plane.

Modifications:
Remove private prefix on configuration.