### PR TITLE
fix: check if control plane URL is null before building URL

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -239,7 +239,14 @@ class GatlingPluginExtension {
         @Input
         @Optional
         URL getControlPlaneUrl() {
-            return controlPlaneUrl ?: new URL(System.getProperty(CONTROL_PLANE_URL))
+            def sysProp = System.getProperty(CONTROL_PLANE_URL)
+            if (controlPlaneUrl != null) {
+                return controlPlaneUrl
+            } else if (sysProp != null && sysProp != ""){
+                return new URL(sysProp)
+            } else {
+                return null
+            }
         }
 
         EnterpriseClient initEnterpriseClient(String version) {


### PR DESCRIPTION
Motivation:
control plane URL is optional but enterprisePackage crash if absent.

Modifications:
Add checks

Result:
No more bug.