### PR TITLE
fix: packaging breaks on cyclic dependencies

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingEnterprisePackageTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterprisePackageTask.groovy
@@ -93,9 +93,11 @@ class GatlingEnterprisePackageTask extends Jar {
     }
 
     private void collectDepAndChildren(ResolvedDependency dep, Set<ResolvedDependency> acc) {
-        acc.add(dep)
-        for (child in dep.children) {
-            collectDepAndChildren(child, acc)
+        if (!acc.contains(dep)) {
+            acc.add(dep)
+            for (child in dep.children) {
+                collectDepAndChildren(child, acc)
+            }
         }
     }
 }


### PR DESCRIPTION
Motivation:

- grpc-java has two modules that depend on each other, causing circular recursion on the collectDepAndChildren function

Modification:

- stop the recursion if the accumulator already contains a dependency

Result:

- stackoverflowless