### PR TITLE
chore: Rework Simulations scan

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -16,6 +16,8 @@ final class GatlingPlugin implements Plugin<Project> {
 
     public static def GATLING_RUN_TASK_NAME = 'gatlingRun'
 
+    public static def GATLING_RECORDER_TASK_NAME = 'gatlingRecorder'
+
     static String GATLING_TASK_NAME_PREFIX = "$GATLING_RUN_TASK_NAME-"
 
     public static def ENTERPRISE_PACKAGE_TASK_NAME = "gatlingEnterprisePackage"
@@ -44,6 +46,11 @@ final class GatlingPlugin implements Plugin<Project> {
         project.tasks.register(GATLING_LOGBACK_TASK_NAME, LogbackConfigTask.class) {
             dependsOn(project.tasks.named("gatlingClasses"))
             description = "Prepare logback config"
+            group = "Gatling"
+        }
+
+        project.tasks.register(GATLING_RECORDER_TASK_NAME, GatlingRecorderTask.class) {
+            description = "Launch recorder"
             group = "Gatling"
         }
 

--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -291,6 +291,8 @@ class GatlingPluginExtension {
 
     static final String GATLING_MAIN_CLASS = 'io.gatling.app.Gatling'
 
+    static final String GATLING_RECORDER_CLASS = 'io.gatling.recorder.GatlingRecorder'
+
     static final String JAVA_SIMULATIONS_DIR = "src/gatling/java"
 
     static final String SCALA_SIMULATIONS_DIR = "src/gatling/scala"
@@ -299,7 +301,7 @@ class GatlingPluginExtension {
 
     static final String RESOURCES_DIR = "src/gatling/resources"
 
-    static final String GATLING_VERSION = '3.10.3'
+    static final String GATLING_VERSION = '3.10.4'
 
     static final String SCALA_VERSION = '2.13.12'
 

--- a/src/main/groovy/io/gatling/gradle/GatlingRecorderTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingRecorderTask.groovy
@@ -1,0 +1,93 @@
+package io.gatling.gradle
+
+import org.gradle.api.Action
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.*
+import org.gradle.process.JavaExecSpec
+import org.gradle.process.internal.ExecException
+
+class GatlingRecorderTask extends DefaultTask {
+
+    @Input
+    @Optional
+    String simulationClass
+
+    @Input
+    @Optional
+    String simulationPackage
+
+    @OutputDirectory
+    File gatlingReportDir = project.file("${project.reportsDir}/gatling")
+
+    GatlingRecorderTask() {
+        outputs.upToDateWhen { false }
+    }
+
+    List<String> createRecorderArgs() {
+        def gatling = project.sourceSets.gatling
+
+        File javaSrcDir = gatling.hasProperty("java") ? gatling.java.srcDirs?.find() : null
+        File scalaSrcDir = gatling.hasProperty("scala") ? gatling.scala.srcDirs?.find() : null
+        File kotlinSrcDir = gatling.hasProperty("kotlin") ? gatling.kotlin.srcDirs?.find() : null
+        File resourcesDir = gatling.resources.srcDirs?.find()
+
+        List<String> args
+        if (scalaSrcDir != null && scalaSrcDir.exists()) {
+            args = [
+                "-sf", scalaSrcDir.getAbsolutePath(),
+                "-fmt", "scala"
+            ]
+        } else if (kotlinSrcDir != null && kotlinSrcDir.exists()) {
+            args = [
+                "-sf", kotlinSrcDir.getAbsolutePath(),
+                "-fmt", "kotlin"
+            ]
+        } else if (javaSrcDir != null && javaSrcDir.exists()) {
+            args = [
+                "-sf", javaSrcDir.getAbsolutePath()
+                // let the Recorder pick a default Java format based on Java version
+            ]
+        } else {
+            throw new IllegalStateException("None of the scala/kotlin/java src dir exist")
+        }
+
+        args += [ "-rf", resourcesDir.getAbsolutePath() ]
+
+        if (simulationPackage != null) {
+            args += [ "-pkg", simulationPackage ]
+        }
+
+        if (simulationClass != null) {
+            args += [ "-cn", simulationClass ]
+        }
+
+        return args
+    }
+
+    @TaskAction
+    void gatlingRecorder() {
+        def gatlingExt = project.extensions.getByType(GatlingPluginExtension)
+
+        def result = project.javaexec({ JavaExecSpec exec ->
+            exec.mainClass.set(GatlingPluginExtension.GATLING_RECORDER_CLASS)
+            exec.classpath = project.configurations.gatlingRuntimeClasspath
+
+            def logbackFile = LogbackConfigTask.logbackFile(project.buildDir)
+            if (logbackFile.exists()) {
+                exec.systemProperty("logback.configurationFile", logbackFile.absolutePath)
+            }
+
+            exec.args this.createRecorderArgs()
+
+            exec.standardInput = System.in
+
+            exec.ignoreExitValue = true
+        } as Action<JavaExecSpec>)
+
+        try {
+            result.rethrowFailure()
+        } catch (ExecException e) {
+            throw new TaskExecutionException(this, new RuntimeException("Failed to launch recorder", e))
+        }
+    }
+}

--- a/src/main/groovy/io/gatling/gradle/GatlingRunTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingRunTask.groovy
@@ -27,7 +27,7 @@ class GatlingRunTask extends DefaultTask {
     Map environment = [:]
 
     @Internal
-    String simulationClass = null
+    String simulationClass
 
     @OutputDirectory
     File gatlingReportDir = project.file("${project.reportsDir}/gatling")


### PR DESCRIPTION
Motivation:

The existing file based filter is bad, in particular as it requires naming the Simulation classes as XXXSimulation.

Modification:

use standard scan mechanism
don't use filters for the user defined simulation class name (gatlingRun-FQCN)
replace file path filters matching source files with ant based filters on class names