### PR TITLE
chore: drop beta package descriptor feature, closes HYB-546

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
@@ -15,14 +15,8 @@ class GatlingEnterpriseUploadTask extends DefaultTask {
         def gatling = project.extensions.getByType(GatlingPluginExtension)
         RecoverEnterprisePluginException.handle(logger) {
             EnterprisePlugin enterprisePlugin = gatling.enterprise.initBatchEnterprisePlugin(project.version.toString(), logger)
-
-            String jsonPackageConfig = PackageConfiguration.loadToJson(project.projectDir)
             UUID packageUUID = gatling.enterprise.packageId
-            if (jsonPackageConfig != null) {
-                logger.lifecycle("Package configuration file detected, applying it.")
-                packageUUID =  enterprisePlugin.uploadPackageConfiguration(jsonPackageConfig)
-                logger.lifecycle("Package id: "+ packageUUID.toString())
-            }
+
             if (packageUUID) {
                 logger.lifecycle("Uploading package with packageId " + packageUUID)
                 enterprisePlugin.uploadPackage(packageUUID, inputs.files.singleFile)


### PR DESCRIPTION
Motivation:
- Package Descriptor feature is going out of beta and v1 is coming

Modifications:
- Remove beta package descriptor deployment call from enterpriseUpload target

Result:
- Beta package descriptor: out