### PR TITLE
fix: Restore original Enterprise package publishing, close MISC-459

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -73,6 +73,7 @@ final class GatlingPlugin implements Plugin<Project> {
 
     private TaskProvider<GatlingEnterprisePackageTask> registerEnterprisePackageTask(Project project) {
         project.tasks.register(ENTERPRISE_PACKAGE_TASK_NAME, GatlingEnterprisePackageTask.class) {packageTask ->
+            packageTask.archiveClassifier.set("tests")
             packageTask.configurations = [
                 project.configurations.gatlingRuntimeClasspath
             ]


### PR DESCRIPTION
Motivation:

A previous commit stopped making GatlingEnterprisePackageTask extend the Jar task as it doesn't contain any useful code for use.

But actually, gradle has some hardcoded behavior for this class regarding publishing.

This broke the publishing process documented in the SH documentation (used to publish in a maven repository).