### PR TITLE
chore: upgrade plugin-commons to 1.9.0-M17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 }
 
 dependencies {
-  implementation "io.gatling:gatling-enterprise-plugin-commons:1.9.0-M14"
+  implementation "io.gatling:gatling-enterprise-plugin-commons:1.9.0-M17"
   constraints {
     implementation('com.fasterxml.jackson.core:jackson-databind') {
       version {

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseDeployTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseDeployTask.groovy
@@ -2,7 +2,6 @@ package io.gatling.gradle
 
 import io.gatling.plugin.BatchEnterprisePlugin
 import io.gatling.plugin.deployment.DeploymentConfiguration
-import io.gatling.plugin.model.BuildTool
 import io.gatling.plugin.model.DeploymentInfo
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
@@ -14,14 +13,12 @@ class GatlingEnterpriseDeployTask extends DefaultTask {
     @TaskAction
     void deploy() {
         final GatlingPluginExtension gatlingPlugin = project.extensions.getByType(GatlingPluginExtension)
-        final String version = project.version.toString()
-        final BatchEnterprisePlugin enterprisePlugin = gatlingPlugin.enterprise.initBatchEnterprisePlugin(version, logger)
-
+        final BatchEnterprisePlugin enterprisePlugin = gatlingPlugin.enterprise.initBatchEnterprisePlugin(logger)
         final File descriptorFile = DeploymentConfiguration.fromBaseDirectory(project.rootDir)
         final File packageFile = inputs.files.singleFile
         final Boolean isPrivateRepositoryEnabled = gatlingPlugin.enterprise.controlPlaneUrl != null
         final String artifactId = project.name
-        final String implementationVersion = (getClass().getPackage().getImplementationVersion() == null) ? "undefined" : getClass().getPackage().getImplementationVersion()
-        deploymentInfo = enterprisePlugin.deployFromDescriptor(descriptorFile, packageFile, artifactId, isPrivateRepositoryEnabled, BuildTool.GRADLE, implementationVersion)
+
+        deploymentInfo = enterprisePlugin.deployFromDescriptor(descriptorFile, packageFile, artifactId, isPrivateRepositoryEnabled)
     }
 }

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseStartTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseStartTask.groovy
@@ -13,13 +13,8 @@ class GatlingEnterpriseStartTask extends GatlingEnterpriseDeployTask {
         super.deploy()
 
         final GatlingPluginExtension gatling = project.extensions.getByType(GatlingPluginExtension)
-        final String version = project.version.toString()
         final boolean waitForRunEnd = gatling.enterprise.waitForRunEnd
-
-        final EnterprisePlugin enterprisePlugin =
-            gatling.enterprise.batchMode ?
-                gatling.enterprise.initBatchEnterprisePlugin(version, logger) :
-                gatling.enterprise.initInteractiveEnterprisePlugin(version, logger)
+        final EnterprisePlugin enterprisePlugin = gatling.enterprise.initEnterprisePlugin(logger)
 
         RecoverEnterprisePluginException.handle(logger) {
             RunSummary runSummary = enterprisePlugin.startSimulation(gatling.enterprise.simulationName, deploymentInfo)

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
@@ -1,6 +1,6 @@
 package io.gatling.gradle
 
-import io.gatling.plugin.EnterprisePlugin
+import io.gatling.plugin.BatchEnterprisePlugin
 import org.gradle.api.DefaultTask
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.CacheableTask
@@ -13,7 +13,7 @@ class GatlingEnterpriseUploadTask extends DefaultTask {
     void publish() {
         def gatling = project.extensions.getByType(GatlingPluginExtension)
         RecoverEnterprisePluginException.handle(logger) {
-            EnterprisePlugin enterprisePlugin = gatling.enterprise.initBatchEnterprisePlugin(project.version.toString(), logger)
+            BatchEnterprisePlugin enterprisePlugin = gatling.enterprise.initBatchEnterprisePlugin(logger)
             UUID packageUUID = gatling.enterprise.packageId
 
             if (packageUUID) {

--- a/src/main/groovy/io/gatling/gradle/UnsupportedClientPluginException.java
+++ b/src/main/groovy/io/gatling/gradle/UnsupportedClientPluginException.java
@@ -1,0 +1,10 @@
+package io.gatling.gradle;
+
+public final class UnsupportedClientPluginException extends Exception {
+    public UnsupportedClientPluginException(Exception cause) {
+        super(
+           "Please update the Gatling Gradle plugin to the latest version for compatibility with Gatling Enterprise. See https://gatling.io/docs/gatling/reference/current/extensions/gradle_plugin/ for more information about this plugin.",
+           cause
+        );
+    }
+}


### PR DESCRIPTION
Motivation:
- Interactive & CI envvar detection should be shared in commons plugin library.

Modifications:
- Upgrade commons to 1.9.0-M17
- Use common EnterprisePlugin and BatchEnterprisePlugin instanciation

Result:
- Less logic in maven plugin, more in common !