### PR TITLE
fix: fix gatlingRecorder task

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingRecorderTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingRecorderTask.groovy
@@ -71,12 +71,6 @@ class GatlingRecorderTask extends DefaultTask {
         def result = project.javaexec({ JavaExecSpec exec ->
             exec.mainClass.set(GatlingPluginExtension.GATLING_RECORDER_CLASS)
             exec.classpath = project.configurations.gatlingRuntimeClasspath
-
-            def logbackFile = LogbackConfigTask.logbackFile(project.buildDir)
-            if (logbackFile.exists()) {
-                exec.systemProperty("logback.configurationFile", logbackFile.absolutePath)
-            }
-
             exec.args this.createRecorderArgs()
 
             exec.standardInput = System.in


### PR DESCRIPTION
Motivation:
gatlingRecorder depends on logbackTask which is no more present.

Modifications:
Remove all logbackTask reference

Result:
We can launch the recorder again.