### PR TITLE
fix: package and simulation ID from system props, closes HYB-690

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -135,7 +135,8 @@ class GatlingPluginExtension {
         @Input
         @Optional
         UUID getSimulationId() {
-            simulationId ?: System.getProperty(SIMULATION_ID_PROPERTY) ?: null
+            def sysProp = System.getProperty(SIMULATION_ID_PROPERTY)
+            return simulationId ?: (sysProp ? UUID.fromString(sysProp) : null)
         }
 
         @Input
@@ -163,7 +164,8 @@ class GatlingPluginExtension {
         @Input
         @Optional
         UUID getPackageId() {
-            packageId ?: System.getProperty(PACKAGE_ID_PROPERTY) ?: null
+            def sysProp = System.getProperty(PACKAGE_ID_PROPERTY)
+            return packageId ?: (sysProp ? UUID.fromString(sysProp) : null)
         }
 
         @Input
@@ -188,13 +190,7 @@ class GatlingPluginExtension {
         @Optional
         URL getControlPlaneUrl() {
             def sysProp = System.getProperty(CONTROL_PLANE_URL)
-            if (controlPlaneUrl != null) {
-                return controlPlaneUrl
-            } else if (sysProp != null && sysProp != ""){
-                return new URL(sysProp)
-            } else {
-                return null
-            }
+            return controlPlaneUrl ?: (sysProp ? new URL(sysProp) : null)
         }
 
         @Input


### PR DESCRIPTION
**Motivation:**
Cast exception when setting package or simulation ID from system props.

**Modification:**
Use `UUID.fromString` when package or simulation ID is compute from system props.