### PR TITLE
chore: Replace deprecated gradle-build-action with setup-gradle

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,9 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Retrieve tag name
         uses: little-core-labs/get-git-tag@v3.0.2
         id: tagName
@@ -24,13 +27,8 @@ jobs:
           tagRegex: "v(.*)"
 
       - name: Publish plugins
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: >
-            publishPlugins
+        run: >
+          ./gradlew publishPlugins
             -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}
             -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}
             -Pversion=${{ steps.tagName.outputs.tag }}
-          wrapper-cache-enabled: true
-          dependencies-cache-enabled: true
-          configuration-cache-enabled: true

--- a/.github/workflows/test-only.yml
+++ b/.github/workflows/test-only.yml
@@ -30,9 +30,8 @@ jobs:
           distribution: 'zulu'
           java-version: '11'
 
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+
       - name: Check
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: check
-          # Disable cache because of corruption
-          cache-disabled: true
+        run: ./gradlew check


### PR DESCRIPTION
Motivation:

Action gradle/gradle-build-action is deprecated. See also: https://github.com/gradle/actions/blob/main/docs/deprecation-upgrade-guide.md#the-action-gradlegradle-build-action-has-been-replaced-by-gradleactionssetup-gradle

Modifications:

Replace with gradle/actions/setup-gradle (to set up Gradle) and a run step (to execute gradlew).