### PR TITLE
fix: Fix parameters for Gradle command in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,8 @@ jobs:
           tagRegex: "v(.*)"
 
       - name: Publish plugins
-        run: >
-          ./gradlew publishPlugins
-            -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }}
-            -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }}
+        run: |
+          ./gradlew publishPlugins \
+            -Pgradle.publish.key=${{ secrets.GRADLE_PUBLISH_KEY }} \
+            -Pgradle.publish.secret=${{ secrets.GRADLE_PUBLISH_SECRET }} \
             -Pversion=${{ steps.tagName.outputs.tag }}


### PR DESCRIPTION
Motivation:

In YAML, folded-style block scalars (with '>') do not insert new lines... Except when the indentation changes. So we had unexpected new lines separating the parameters from the command.

Modifications:

Use a literal-style block scalar (with '|') and add backslashes to continue the command. At least it's explicit and there is no surprising behavior.

Result:

Parameters are properly passed to the Gradle command when executing the publish workflow.