### PR TITLE
chore: handle simulation validation ID on deploy command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ repositories {
 }
 
 dependencies {
-  implementation "io.gatling:gatling-enterprise-plugin-commons:1.16.3"
+  implementation "io.gatling:gatling-enterprise-plugin-commons:1.17.1"
   implementation "io.gatling:gatling-shared-cli:0.0.6"
 
   testImplementation('org.spockframework:spock-core:2.3-groovy-3.0') {

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseDeployTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseDeployTask.groovy
@@ -17,8 +17,11 @@ class GatlingEnterpriseDeployTask extends DefaultTask {
         final File descriptorFile = DeploymentConfiguration.fromBaseDirectory(project.rootDir, gatlingPlugin.enterprise.packageDescriptorFilename)
         final File packageFile = inputs.files.singleFile
         final Boolean isPrivateRepositoryEnabled = gatlingPlugin.enterprise.controlPlaneUrl != null
+        final String validateSimulationId = gatlingPlugin.enterprise.validateSimulationId;
         final String artifactId = project.name
 
-        deploymentInfo = enterprisePlugin.deployFromDescriptor(descriptorFile, packageFile, artifactId, isPrivateRepositoryEnabled)
+        deploymentInfo = validateSimulationId != null
+            ? enterprisePlugin.deployFromDescriptor(descriptorFile, packageFile, artifactId, isPrivateRepositoryEnabled, validateSimulationId)
+            : enterprisePlugin.deployFromDescriptor(descriptorFile, packageFile, artifactId, isPrivateRepositoryEnabled)
     }
 }

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterpriseUploadTask.groovy
@@ -1,9 +1,8 @@
 package io.gatling.gradle
 
-import io.gatling.plugin.BatchEnterprisePlugin
-import io.gatling.plugin.ConfigurationConstants
+
+import kotlin.NotImplementedError
 import org.gradle.api.DefaultTask
-import org.gradle.api.InvalidUserDataException
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.TaskAction
 
@@ -12,22 +11,9 @@ class GatlingEnterpriseUploadTask extends DefaultTask {
 
     @TaskAction
     void publish() {
-        def gatling = project.extensions.getByType(GatlingPluginExtension)
-        RecoverEnterprisePluginException.handle(logger) {
-            BatchEnterprisePlugin enterprisePlugin = gatling.enterprise.initBatchEnterprisePlugin(logger)
-            UUID packageUUID = gatling.enterprise.packageId
-
-            if (packageUUID) {
-                logger.lifecycle("Uploading package with packageId " + packageUUID)
-                enterprisePlugin.uploadPackage(packageUUID, inputs.files.singleFile)
-            } else if (gatling.enterprise.simulationId) {
-                logger.lifecycle("Uploading package belonging to the simulation " + gatling.enterprise.simulationId)
-                enterprisePlugin.uploadPackageWithSimulationId(gatling.enterprise.simulationId, inputs.files.singleFile)
-            } else {
-                throw new InvalidUserDataException("You need to either configure gatling.enterprise.packageId (or pass it with '-D${ConfigurationConstants.UploadOptions.PackageId.SYS_PROP}=<PACKAGE_ID>') " +
-                    "or gatling.enterprise.simulationId (or pass it with '-D${ConfigurationConstants.UploadOptions.SimulationId.SYS_PROP}=<SIMULATION_ID>') to upload a package." +
-                    "Please see https://docs.gatling.io/reference/integrations/build-tools/gradle-plugin/#running-your-simulations-on-gatling-enterprise-cloud for more information.")
-            }
-        }
+        throw new NotImplementedError(
+            "The enterprise upload command is no longer supported. It has been replaced by the enterprise deploy command." +
+                " Refer to the documentation for more information: https://docs.gatling.io/reference/integrations/build-tools/gradle-plugin/#deploying-on-gatling-enterprise"
+        )
     }
 }

--- a/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPlugin.groovy
@@ -35,16 +35,13 @@ final class GatlingPlugin implements Plugin<Project> {
         }
 
         def gatlingEnterprisePackageTask = registerEnterprisePackageTask(project)
-        registerEnterpriseUploadTask(project, gatlingEnterprisePackageTask)
+        registerEnterpriseUploadTask(project)
         registerEnterpriseDeployTask(project, gatlingEnterprisePackageTask)
         registerEnterpriseStartTask(project, gatlingEnterprisePackageTask)
     }
 
-    private void registerEnterpriseUploadTask(Project project, TaskProvider<GatlingEnterprisePackageTask> gatlingEnterprisePackageTask) {
-        project.tasks.register(ENTERPRISE_UPLOAD_TASK_NAME, GatlingEnterpriseUploadTask.class) {
-            inputs.files gatlingEnterprisePackageTask
-            dependsOn(gatlingEnterprisePackageTask)
-        }
+    private static void registerEnterpriseUploadTask(Project project) {
+        project.tasks.register(ENTERPRISE_UPLOAD_TASK_NAME, GatlingEnterpriseUploadTask.class)
     }
 
     private TaskProvider<GatlingEnterpriseDeployTask> registerEnterpriseDeployTask(Project project, TaskProvider<GatlingEnterprisePackageTask> gatlingEnterprisePackageTask) {

--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -240,7 +240,7 @@ class GatlingPluginExtension {
         }
 
         private PluginConfiguration getPluginConfiguration(Logger logger, boolean forceBatchMode) {
-            final apiToken = ConfigurationConstants.ApiToken.value()
+            final apiToken = getApiToken()
             if (!apiToken) {
                 throw new InvalidUserDataException("""
                     |An API token is required to call the Gatling Enterprise server.

--- a/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingPluginExtension.groovy
@@ -33,6 +33,7 @@ class GatlingPluginExtension {
         private boolean waitForRunEnd
         private String controlPlaneUrl
         private String packageDescriptorFilename
+        private String validateSimulationId
 
         def setBatchMode(boolean batchMode) {
             this.batchMode = batchMode
@@ -130,6 +131,15 @@ class GatlingPluginExtension {
             setPackageDescriptorFilename(packageDescriptorFilename)
         }
 
+        def setValidateSimulationId(String validateSimulationId) {
+            this.validateSimulationId = validateSimulationId
+        }
+
+        def validateSimulationId(String validateSimulationId) {
+            this.validateSimulationId = validateSimulationId
+        }
+
+
         @Input
         @Optional
         UUID getSimulationId() {
@@ -201,6 +211,12 @@ class GatlingPluginExtension {
         @Optional
         String getPackageDescriptorFilename() {
             ConfigurationConstants.DeployOptions.PackageDescriptorFilename.valueOf(packageDescriptorFilename)
+        }
+
+        @Input
+        @Optional
+        String getValidateSimulationId() {
+            ConfigurationConstants.DeployOptions.ValidateSimulationId.valueOf(validateSimulationId)
         }
 
         BatchEnterprisePlugin initBatchEnterprisePlugin(Logger logger) {


### PR DESCRIPTION
[chore: drop enterprise upload command with expressive message](https://github.com/gatling/gatling-gradle-plugin/commit/9e801734a97d4ac618b6f0d5257d20df5ecd2852)

**Motivation:**
Command is replaced by enterprise deploy.

**Modification:**
Drop command support, when command is called an error message redirect to deploy command documentation.

[chore: handle simulation validation ID on deploy command](https://github.com/gatling/gatling-gradle-plugin/commit/e8b0806875ca4b611468670c1fd776c3a78e7dff)

**Motivation:**
Validate a given simulation ID have been deployed.

[fix: retrieve API token from configuration when available](https://github.com/gatling/gatling-gradle-plugin/commit/b179c8fadd0c35ad012621c78973f6e6c90530ec)

**Motivation:**
API Token was configurable but not used (only available from system properties or environment)

**Modification:**
Use configuration for API Token when available.