### PR TITLE
chore: add Gradle 9 to the test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: 'test-only'
+name: 'build'
 
 on:
   push:
@@ -18,9 +18,17 @@ on:
       - LICENSE.txt
       - LICENSE
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,21 @@
-name: 'publish'
+name: 'release'
 
 on:
   push:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,16 +1,26 @@
 plugins {
   id 'java-gradle-plugin'
-  id 'com.gradle.plugin-publish' version '1.3.1'
+  id 'com.gradle.plugin-publish' version "2.0.0"
   id 'groovy'
 }
 
 group = "gradle.plugin.io.gatling.gradle"
 
+compileJava {
+  options.release = 11
+}
+
+compileGroovy {
+  options.release = 11
+}
+
 java {
   toolchain {
-    languageVersion.set(JavaLanguageVersion.of(11))
+    // highest Java version supported by the current Gradle range we support (see GatlingFuncSpec)
+    languageVersion.set(JavaLanguageVersion.of(21))
   }
 }
+
 jar {
   manifest {
     attributes 'Implementation-Version': project.version
@@ -25,10 +35,10 @@ dependencies {
   implementation "io.gatling:gatling-enterprise-plugin-commons:1.20.2"
   implementation "io.gatling:gatling-shared-cli:0.0.6"
 
-  testImplementation('org.spockframework:spock-core:2.3-groovy-3.0') {
+  testImplementation('org.spockframework:spock-core:2.3-groovy-4.0') {
     exclude module: 'groovy'
   }
-  testImplementation 'org.spockframework:spock-junit4:2.3-groovy-3.0'
+  testImplementation 'org.spockframework:spock-junit4:2.3-groovy-4.0'
   testImplementation('com.github.stefanbirkner:system-rules:1.19.0') {
     exclude module: 'junit-dep'
   }
@@ -44,6 +54,8 @@ test {
     showStandardStreams = false
   }
   useJUnitPlatform()
+  // required for Spock, see https://docs.gradle.org/current/userguide/upgrading_version_7.html#remove_test_add_opens
+  jvmArgs = ["--add-opens=java.base/java.util=ALL-UNNAMED"]
 }
 
 gradlePlugin {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/groovy/io/gatling/gradle/GatlingEnterprisePackageTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingEnterprisePackageTask.groovy
@@ -13,7 +13,8 @@ import org.gradle.api.tasks.*
 import org.gradle.jvm.tasks.Jar
 
 @DisableCachingByDefault(because = "Must always run, target file is configured environment variable in enterprise packager")
-class GatlingEnterprisePackageTask extends Jar {
+// abstract because https://docs.gradle.org/current/userguide/upgrading_major_version_9.html#injection_getters_are_now_abstract
+abstract class GatlingEnterprisePackageTask extends Jar {
 
     private static final Set<String> EXCLUDED_NETTY_ARTIFACTS = ["netty-all", "netty-resolver-dns-classes-macos", "netty-resolver-dns-native-macos"].asUnmodifiable()
 

--- a/src/test/groovy/func/WhenGroovyRunScalaSimulationSysPropsJvmArgsSpec.groovy
+++ b/src/test/groovy/func/WhenGroovyRunScalaSimulationSysPropsJvmArgsSpec.groovy
@@ -35,7 +35,7 @@ class WhenGroovyRunScalaSimulationSysPropsJvmArgsSpec extends GatlingFuncSpec {
         when: "override via gatling extension"
         buildFile << """
 gatling {
-    jvmArgs = ['-Xms32m']
+    jvmArgs = ['-Xms32m', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED']
 }
 """
         and:
@@ -58,14 +58,14 @@ gatling {
         when: "override via gatling extension"
         buildFile << """
 gatling {
-    jvmArgs = ['-Xms32m', '-XX:+UseG1GC']
+    jvmArgs = ['-Xms32m', '-XX:+UseG1GC', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED']
 }
 """
         and:
         result = executeGradle("--rerun-tasks", GATLING_RUN_TASK_NAME)
         then:
         with(new GatlingDebug(result)) {
-            jvmArgs.sort() == ['-Xms32m', '-XX:+UseG1GC'].sort()
+            jvmArgs.sort() == ['-Xms32m', '-XX:+UseG1GC', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED'].sort()
         }
     }
 
@@ -76,14 +76,14 @@ gatling {
     jvmArgs = ['-Xms32m', '-XX:+AggressiveOpts']
 }
 gatlingRun {
-    jvmArgs = ['-Xms128m', '-XX:+UseG1GC']
+    jvmArgs = ['-Xms128m', '-XX:+UseG1GC', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED']
 }
 """
         and:
         def result = executeGradle(GATLING_RUN_TASK_NAME)
         then:
         with(new GatlingDebug(result)) {
-            jvmArgs.sort() == ['-Xms128m', '-XX:+UseG1GC'].sort()
+            jvmArgs.sort() == ['-Xms128m', '-XX:+UseG1GC', '--add-opens=java.base/java.lang=ALL-UNNAMED', '--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED'].sort()
         }
     }
 

--- a/src/test/groovy/helper/GatlingFuncSpec.groovy
+++ b/src/test/groovy/helper/GatlingFuncSpec.groovy
@@ -39,5 +39,5 @@ abstract class GatlingFuncSpec extends GatlingSpec {
         createRunner(gradleArgs).build()
     }
 
-    protected static final List<String> SUPPORTED_GRADLE_VERSIONS = ["8.4", "8.14.3"]
+    protected static final List<String> SUPPORTED_GRADLE_VERSIONS = ["8.4", "8.14.3", "9.1.0"]
 }


### PR DESCRIPTION
Modifications:

* build with Java 21 (highest version supported in our gradle range) but make sure to emit Java 11 bytecode
* build with Gradle 9.1.0
* as we now execute the tests with Java 21, Gatling functional tests need some --add-opens JVM options
* as we now execute the tests with Java 21, Spock needs an --add-opens JVM option
* GatlingEnterprisePackageTask needs to be abstract now