### PR TITLE
fix: Lazy load gatlingReportDir for GatlingRunTask and GatlingRecorde…

### DIFF
--- a/src/main/groovy/io/gatling/gradle/GatlingRecorderTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingRecorderTask.groovy
@@ -4,6 +4,8 @@ import io.gatling.shared.cli.RecorderCliOptions
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.*
 import org.gradle.process.ExecOperations
 import org.gradle.process.JavaExecSpec
@@ -22,7 +24,7 @@ class GatlingRecorderTask extends DefaultTask {
     String simulationPackage
 
     @OutputDirectory
-    File gatlingReportDir = project.layout.buildDirectory.dir("reports/gatling").get().getAsFile()
+    Provider<Directory> gatlingReportDir = project.layout.buildDirectory.dir("reports/gatling")
 
     protected final ExecOperations execOperations
     protected final Configuration gatlingRuntimeClasspathConfiguration = project.configurations.gatlingRuntimeClasspath

--- a/src/main/groovy/io/gatling/gradle/GatlingRunTask.groovy
+++ b/src/main/groovy/io/gatling/gradle/GatlingRunTask.groovy
@@ -7,6 +7,8 @@ import io.gatling.shared.cli.GatlingCliOptions
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.file.Directory
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectory
@@ -65,7 +67,7 @@ class GatlingRunTask extends DefaultTask {
     boolean runInSameProcess
 
     @OutputDirectory
-    File gatlingReportDir = project.layout.buildDirectory.dir("reports/gatling").get().getAsFile()
+    Provider<Directory> gatlingReportDir = project.layout.buildDirectory.dir("reports/gatling")
 
     protected final ExecOperations execOperations
     protected final GatlingPluginExtension gatlingExt = project.extensions.getByType(GatlingPluginExtension)
@@ -167,7 +169,7 @@ class GatlingRunTask extends DefaultTask {
     List<String> createGatlingArgs(String simulationClass) {
         def baseArgs = [
             GatlingCliOptions.Simulation.shortOption(), simulationClass,
-            GatlingCliOptions.ResultsFolder.shortOption(), gatlingReportDir.absolutePath,
+            GatlingCliOptions.ResultsFolder.shortOption(), gatlingReportDir.get().asFile.absolutePath,
             GatlingCliOptions.Launcher.shortOption(), "gradle",
             GatlingCliOptions.BuildToolVersion.shortOption(), GradleVersion.current().version
         ]


### PR DESCRIPTION
fix: Lazy load gatlingReportDir for GatlingRunTask and GatlingRecorderTask

Motivation:

Previously, this caused errors during Gradle’s configuration phase for new Gradle projects with build directories that didn't exist yet.

With this change, gatlingReportDir is only resolved during task execution